### PR TITLE
refactor: nullability fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Build project
       id: build
       run: |
-        dotnet build
+        dotnet build /warnaserror

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -274,7 +274,8 @@ namespace FireboltDotNetSdk.Tests
             conn.Open();
             var command = conn.CreateCursor();
             command.Execute("SELECT 'hello_world_123ツ\n\u0048'::bytea");
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response == null);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Data[0], Is.EqualTo(Encoding.UTF8.GetBytes("hello_world_123ツ\n\u0048")));
         }
     }

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -27,7 +27,8 @@ namespace FireboltDotNetSdk.Tests
             var cursor = conn.CreateCursor();
 
             var value = cursor.Execute(commandText);
-            Assert.IsNotEmpty(value.Data);
+            Assert.NotNull(value);
+            Assert.IsNotEmpty(value!.Data);
         }
 
         [Ignore("sleepEachRow function is currently not supported on staging")]
@@ -43,7 +44,8 @@ namespace FireboltDotNetSdk.Tests
             cursor.Execute("SET use_standard_sql=0");
 
             var value = cursor.Execute(commandText);
-            Assert.IsNotEmpty(value.Data);
+            Assert.NotNull(value);
+            Assert.IsNotEmpty(value!.Data);
         }
 
         [TestCase("select * from information_schema.tables")]
@@ -57,7 +59,8 @@ namespace FireboltDotNetSdk.Tests
             conn.SetEngine(Engine);
 
             var value = conn.CreateCursor().Execute(commandText);
-            Assert.IsNotEmpty(value.Data);
+            Assert.NotNull(value);
+            Assert.IsNotEmpty(value!.Data);
         }
 
         [Test]
@@ -65,8 +68,9 @@ namespace FireboltDotNetSdk.Tests
         {
             var connString = $"database={Database};username={Username};password=wrongPassword;endpoint={Endpoint};";
             using var conn = new FireboltConnection(connString);
-            FireboltException exception = Assert.Throws<FireboltException>(() => conn.Open());
-            Assert.IsTrue(exception.Message.Contains("The operation is forbidden\nStatus: 403") || exception.Message.Contains("429"));
+            FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
+            Assert.NotNull(exception);
+            Assert.IsTrue(exception!.Message.Contains("The operation is forbidden\nStatus: 403") || exception.Message.Contains("429"));
             Assert.IsTrue(exception.ToString().Contains("FireboltDotNetSdk.Exception.FireboltException: The operation is forbidden\nStatus: 403") || exception.Message.Contains("429"));
         }
 
@@ -82,7 +86,8 @@ namespace FireboltDotNetSdk.Tests
             var command = conn.CreateCursor();
             command.Execute("SELECT '2022-05-10 23:01:02.123455'::timestampntz");
             DateTime dt = new DateTime(2022, 5, 10, 23, 1, 2, 0).AddTicks(1234550);
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Meta, Is.EqualTo("TimestampNtz"));
             Assert.That(newMeta.Data[0], Is.EqualTo(dt));
         }
@@ -99,7 +104,8 @@ namespace FireboltDotNetSdk.Tests
             var command = conn.CreateCursor();
             command.Execute("SELECT '2022-05-10'::pgdate");
             DateTime dt = new DateTime(2022, 5, 10, 0, 0, 0);
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Meta, Is.EqualTo("Date"));
             Assert.That(newMeta.Data[0], Is.EqualTo(DateOnly.FromDateTime(dt)));
         }
@@ -117,7 +123,8 @@ namespace FireboltDotNetSdk.Tests
             command.Execute("SELECT '2022-05-10 23:01:02.123456 Europe/Berlin'::timestamptz");
 
             DateTime dt = DateTime.Parse("2022-05-10 21:01:02.123456Z");
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Data[0], Is.EqualTo(dt));
             Assert.That(newMeta.Meta, Is.EqualTo("TimestampTz"));
 
@@ -137,7 +144,8 @@ namespace FireboltDotNetSdk.Tests
             command.Execute("SELECT '2022-05-11 23:01:02.123123 Europe/Berlin'::timestamptz");
 
             DateTime dt = DateTime.Parse("2022-05-11 21:01:02.123123Z");
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Data[0], Is.EqualTo(dt));
             Assert.That(newMeta.Meta, Is.EqualTo("TimestampTz"));
         }
@@ -156,7 +164,8 @@ namespace FireboltDotNetSdk.Tests
             command.Execute("SELECT '1111-01-05 17:04:42.123456'::timestamptz");
 
             DateTime dt = DateTime.Parse("1111-01-05 11:11:14.123456Z");
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Data[0], Is.EqualTo(dt));
             Assert.That(newMeta.Meta, Is.EqualTo("TimestampTz"));
         }
@@ -173,7 +182,8 @@ namespace FireboltDotNetSdk.Tests
             command.Execute("SELECT '2022-05-01 12:01:02.123456'::timestamptz");
 
             DateTime dt = DateTime.Parse("2022-05-01 12:01:02.123456Z");
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Data[0], Is.EqualTo(dt));
             Assert.That(newMeta.Meta, Is.EqualTo("TimestampTz"));
         }
@@ -192,7 +202,8 @@ namespace FireboltDotNetSdk.Tests
             command.Execute("SET output_format_firebolt_type_names=true");
             command.Execute("SET bool_output_format=postgres");
             command.Execute("SELECT true::boolean");
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Meta, Is.EqualTo("Boolean"));
             Assert.That(newMeta.Data[0], Is.EqualTo(true));
         }
@@ -205,7 +216,8 @@ namespace FireboltDotNetSdk.Tests
             conn.Open();
             var command = conn.CreateCursor();
             var value = command.Execute("SELECT 1");
-            Assert.That(value.Data[0][0], Is.EqualTo(1));
+            Assert.NotNull(value);
+            Assert.That(value!.Data[0][0], Is.EqualTo(1));
         }
 
         [Test]
@@ -213,16 +225,18 @@ namespace FireboltDotNetSdk.Tests
         {
             var connString = $"database={Database};username={ClientId};password=wrongPassword;endpoint={Endpoint};";
             using var conn = new FireboltConnection(connString);
-            FireboltException exception = Assert.Throws<FireboltException>(() => conn.Open());
-            Assert.IsTrue(exception.Message.Contains("401"));
+            FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
+            Assert.NotNull(exception);
+            Assert.IsTrue(exception!.Message.Contains("401"));
         }
         [Test]
         public void ExecuteServiceAccountLoginWithMissingSecret()
         {
             var connString = $"database={Database};username={ClientId};password=;endpoint={Endpoint};";
             using var conn = new FireboltConnection(connString);
-            FireboltException exception = Assert.Throws<FireboltException>(() => conn.Open());
-            Assert.IsTrue(exception.Message.Contains("Password parameter is missing in the connection string"));
+            FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
+            Assert.NotNull(exception);
+            Assert.IsTrue(exception!.Message.Contains("Password parameter is missing in the connection string"));
         }
         [Test]
         public void ExecuteSelectArray()
@@ -232,7 +246,8 @@ namespace FireboltDotNetSdk.Tests
             conn.Open();
             var command = conn.CreateCursor();
             var res = command.Execute("select [1,NULL,3]");
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Data[0], Is.EqualTo(new int?[] { 1, null, 3 }));
         }
 
@@ -246,7 +261,8 @@ namespace FireboltDotNetSdk.Tests
             command.Execute("select [[1,NULL,3]]");
             int?[][] jaggedArray = new int?[1][];
             jaggedArray[0] = new int?[] { 1, null, 3 };
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response);
+            Assert.NotNull(command.Response);
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Data[0], Is.EqualTo(jaggedArray));
         }
 

--- a/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
@@ -7,7 +7,7 @@ namespace FireboltDotNetSdk.Tests
     [TestFixture]
     internal class SystemEngineTest : IntegrationTest
     {
-        private FireboltConnection? Connection;
+        private FireboltConnection Connection = null!;
         private static int suffix = new Random().Next(9999999);
         private static string newEngineName = "system_engine_dotnet_test_" + suffix;
         private static string newDatabaseName = "system_engine_dotnet_test_" + suffix;
@@ -80,8 +80,8 @@ namespace FireboltDotNetSdk.Tests
             var cursor = Connection.CreateCursor();
 
             var res = cursor.Execute("SHOW DATABASES");
-
-            Assert.That(res.Data.Select(item => item[0]), Has.Exactly(1).EqualTo(newDatabaseName));
+            Assert.NotNull(res);
+            Assert.That(res!.Data.Select(item => item[0]), Has.Exactly(1).EqualTo(newDatabaseName));
 
         }
 
@@ -89,14 +89,18 @@ namespace FireboltDotNetSdk.Tests
         {
             var res = cursor.Execute("SHOW ENGINES");
 
+            Assert.NotNull(res);
             Assert.That(
-        res.Data.Select(item => item[0]), Has.Exactly(1).EqualTo(engineName),
+        res!.Data.Select(item => item[0]), Has.Exactly(1).EqualTo(engineName),
         "Engine {engineName} is missing in SHOW ENGINES"
         );
             Assert.That(
-        res.Data.Select(item => new object[] { item[0], item[5] }), Has.Exactly(1).EqualTo(new object[] { engineName, dbName }),
-        $"Engine {engineName} doesn't have {dbName} database attached in SHOW ENGINES"
-        );
+                res.Data.Select(
+                    item => new object[] { item[0] ?? "", item[5] ?? "" }
+                ),
+                Has.Exactly(1).EqualTo(new object[] { engineName, dbName }),
+                $"Engine {engineName} doesn't have {dbName} database attached in SHOW ENGINES"
+            );
         }
 
         [Test]
@@ -119,13 +123,20 @@ namespace FireboltDotNetSdk.Tests
         {
             var res = cursor.Execute($"SHOW ENGINES");
 
+            Assert.NotNull(res);
             Assert.That(
-        res.Data.Select(item => item[0]), Has.Exactly(1).EqualTo(engineName),
-        $"Engine {engineName} is missing in SHOW ENGINES"
-        );
+                res!.Data.Select(
+                    item => item[0]
+                ),
+                Has.Exactly(1).EqualTo(engineName),
+                $"Engine {engineName} is missing in SHOW ENGINES"
+            );
             Assert.That(
-            res.Data.Select(item => new object[] { item[0], item[2] }), Has.Exactly(1).EqualTo(new object[] { newEngineName, spec }),
-            $"Engine {engineName} should have {spec} spec in SHOW ENGINES"
+                res.Data.Select(
+                    item => new object[] { item[0] ?? "", item[2] ?? "" }
+                ),
+                Has.Exactly(1).EqualTo(new object[] { newEngineName, spec }),
+                $"Engine {engineName} should have {spec} spec in SHOW ENGINES"
             );
         }
 
@@ -146,13 +157,17 @@ namespace FireboltDotNetSdk.Tests
         {
             var res = cursor.Execute("SHOW ENGINES");
 
+            Assert.NotNull(res);
             Assert.That(
-            res.Data.Select(item => item[0]), Has.Exactly(1).EqualTo(engineName),
+            res!.Data.Select(item => item[0]), Has.Exactly(1).EqualTo(engineName),
             "Engine {engineName} is missing in SHOW ENGINES"
             );
             Assert.That(
-            res.Data.Select(item => new object[] { item[0], item[4] }), Has.Exactly(1).EqualTo(new object[] { engineName, status }),
-            "Engine {engineName} should have {status} status"
+                res.Data.Select(
+                    item => new object[] { item[0] ?? "", item[4] ?? "" }
+                ),
+                Has.Exactly(1).EqualTo(new object[] { engineName, status }),
+                "Engine {engineName} should have {status} status"
             );
         }
 

--- a/FireboltDotNetSdk.Tests/Unit/ColumnTypeTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/ColumnTypeTest.cs
@@ -14,7 +14,8 @@ public class ColumnTypeTest
         Assert.False(columnType.Nullable);
         Assert.Null(columnType.Precision);
         Assert.Null(columnType.Scale);
-        Assert.True(columnType.InnerType.Nullable);
+        Assert.NotNull(columnType.InnerType);
+        Assert.True(columnType.InnerType!.Nullable);
         Assert.That(columnType.InnerType.Type, Is.EqualTo(FireboltDataType.Int));
     }
 
@@ -27,7 +28,8 @@ public class ColumnTypeTest
         Assert.True(columnType.Nullable);
         Assert.Null(columnType.Precision);
         Assert.Null(columnType.Scale);
-        Assert.True(columnType.InnerType.Nullable);
+        Assert.NotNull(columnType.InnerType);
+        Assert.True(columnType.InnerType!.Nullable);
         Assert.That(columnType.InnerType.Type, Is.EqualTo(FireboltDataType.Int));
     }
 
@@ -50,9 +52,11 @@ public class ColumnTypeTest
         Assert.False(columnType.Nullable);
         Assert.Null(columnType.Precision);
         Assert.Null(columnType.Scale);
-        Assert.True(columnType.InnerType.Nullable);
+        Assert.NotNull(columnType.InnerType);
+        Assert.True(columnType.InnerType!.Nullable);
         Assert.That(columnType.InnerType.Type, Is.EqualTo(FireboltDataType.Array));
-        Assert.True(columnType.InnerType.InnerType.Nullable);
+        Assert.NotNull(columnType.InnerType.InnerType);
+        Assert.True(columnType.InnerType!.InnerType!.Nullable);
         Assert.That(columnType.InnerType.InnerType.Type, Is.EqualTo(FireboltDataType.Decimal));
         Assert.That(columnType.InnerType.InnerType.Precision, Is.EqualTo(5));
         Assert.That(columnType.InnerType.InnerType.Scale, Is.EqualTo(2));

--- a/FireboltDotNetSdk.Tests/Unit/FireboltClientTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltClientTest.cs
@@ -10,16 +10,18 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteQueryAsyncNullDataTest()
         {
             FireboltClient client = new FireboltClient("test.api.firebolt.io", "any", "any");
-            FireboltException exception = Assert.Throws<FireboltException>(() => client.ExecuteQueryAsync("", "databaseName", "commandText", new HashSet<string>(), CancellationToken.None)
+            FireboltException? exception = Assert.Throws<FireboltException>(() => client.ExecuteQueryAsync("", "databaseName", "commandText", new HashSet<string>(), CancellationToken.None)
                     .GetAwaiter().GetResult());
-            Assert.That(exception.Message, Is.EqualTo("Some parameters are null or empty: engineEndpoint: , databaseName: databaseName or query: commandText"));
+            Assert.NotNull(exception);
+            Assert.That(exception!.Message, Is.EqualTo("Some parameters are null or empty: engineEndpoint: , databaseName: databaseName or query: commandText"));
         }
         [Test]
         public void GetAccountIdByNameAsyncTest()
         {
             FireboltClient client = new FireboltClient("test.api.firebolt.io", "any", "any");
-            FireboltException exception = Assert.Throws<FireboltException>(() => client.GetAccountIdByNameAsync(null, CancellationToken.None).GetAwaiter().GetResult());
-            Assert.That(exception.Message, Is.EqualTo("Account name is empty"));
+            FireboltException? exception = Assert.Throws<FireboltException>(() => client.GetAccountIdByNameAsync(null, CancellationToken.None).GetAwaiter().GetResult());
+            Assert.NotNull(exception);
+            Assert.That(exception!.Message, Is.EqualTo("Account name is empty"));
         }
 
         [Test]
@@ -34,8 +36,9 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteQueryWithoutAccessTokenExceptionTest()
         {
             FireboltClient client = new FireboltClient("test.api.firebolt.io", "any", "any");
-            FireboltException exception = Assert.Throws<FireboltException>(() => client.ExecuteQuery("DBName", "EngineURL", "Select 1").GetAwaiter().GetResult());
-            Assert.That(exception.Message, Is.EqualTo("The Access token is null or empty - EstablishConnection must be called"));
+            FireboltException? exception = Assert.Throws<FireboltException>(() => client.ExecuteQuery("DBName", "EngineURL", "Select 1").GetAwaiter().GetResult());
+            Assert.NotNull(exception);
+            Assert.That(exception!.Message, Is.EqualTo("The Access token is null or empty - EstablishConnection must be called"));
         }
 
         [Test]
@@ -44,7 +47,8 @@ namespace FireboltDotNetSdk.Tests
             FireboltClient client = new FireboltClient("test.api.firebolt.io", "any", "any");
             var tokenField = client.GetType().GetField("_loginToken", System.Reflection.BindingFlags.NonPublic
                                                                       | System.Reflection.BindingFlags.Instance);
-            tokenField.SetValue(client, new FireboltClient.Token("abc", null, null));
+            Assert.NotNull(tokenField);
+            tokenField!.SetValue(client, new FireboltClient.Token("abc", null, null));
             Assert.ThrowsAsync<HttpRequestException>(() => { client.ExecuteQuery("DBName", "EngineURL", "Select 1").GetAwaiter().GetResult(); return Task.CompletedTask; });
         }
 
@@ -54,7 +58,8 @@ namespace FireboltDotNetSdk.Tests
             FireboltClient client = new FireboltClient("user", "password", "http://test.api.firebolt.io");
             var tokenField = client.GetType().GetField("_loginToken", System.Reflection.BindingFlags.NonPublic
                                                                 | System.Reflection.BindingFlags.Instance);
-            tokenField.SetValue(client, new FireboltClient.Token("abc", null, null));
+            Assert.NotNull(tokenField);
+            tokenField!.SetValue(client, new FireboltClient.Token("abc", null, null));
             Assert.ThrowsAsync<HttpRequestException>(() => { client.ExecuteQuery("endpoint_url", "DBName", "Select 1").GetAwaiter().GetResult(); return Task.CompletedTask; });
         }
     }

--- a/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
@@ -6,7 +6,7 @@ namespace FireboltDotNetSdk.Tests
     [TestFixture]
     public class FireboltCommandTest
     {
-        private FireboltCommand _fireboltCommand;
+        private FireboltCommand _fireboltCommand = null!;
 
         [SetUp]
         public void Init()
@@ -29,23 +29,26 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteWrongWaySelectTest(string commandText)
         {
             var cs = new FireboltCommand();
-            FireboltException exception = Assert.Throws<FireboltException>(() => cs.Execute(commandText));
-            Assert.That(exception.Message, Is.EqualTo("Response is empty while GetOriginalJSONData"));
+            FireboltException? exception = Assert.Throws<FireboltException>(() => cs.Execute(commandText));
+            Assert.NotNull(exception);
+            Assert.That(exception!.Message, Is.EqualTo("Response is empty while GetOriginalJSONData"));
         }
 
         [Test]
         public void GetOriginalJsonDataExceptionTest()
         {
             var cs = new FireboltCommand();
-            FireboltException exception = Assert.Throws<FireboltException>(() => cs.GetOriginalJsonData());
-            Assert.That(exception.Message, Is.EqualTo("Response is empty while GetOriginalJSONData"));
+            FireboltException? exception = Assert.Throws<FireboltException>(() => cs.GetOriginalJsonData());
+            Assert.NotNull(exception);
+            Assert.That(exception!.Message, Is.EqualTo("Response is empty while GetOriginalJSONData"));
         }
 
         [Test]
         public void GetOriginalJsonDataTest()
         {
             var result = _fireboltCommand.GetOriginalJsonData();
-            Assert.IsNotNull(result.Data.Count);
+            Assert.NotNull(result);
+            Assert.IsNotNull(result!.Data.Count);
         }
 
         [Test]
@@ -59,8 +62,9 @@ namespace FireboltDotNetSdk.Tests
         public void RowCountExcecptionTest()
         {
             var cs = new FireboltCommand();
-            FireboltException exception = Assert.Throws<FireboltException>(() => cs.RowCount());
-            Assert.That(exception.Message, Is.EqualTo("RowCount is missing"));
+            FireboltException? exception = Assert.Throws<FireboltException>(() => cs.RowCount());
+            Assert.NotNull(exception);
+            Assert.That(exception!.Message, Is.EqualTo("RowCount is missing"));
         }
 
         [TestCase("SET param=1")]

--- a/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
@@ -56,8 +56,9 @@ namespace FireboltDotNetSdk.Tests
             const string connectionString = "database=testdb.ib;username=testuser;password=;account=accountname;endpoint=endpoint";
             var cs = new FireboltConnection(connectionString);
 
-            FireboltException exception = Throws<FireboltException>(() => cs.SetEngine("default_Engine"));
-            That(exception.Message, Does.StartWith("Cannot get engine: default_Engine from testdb.ib database"));
+            FireboltException? exception = Throws<FireboltException>(() => cs.SetEngine("default_Engine"));
+            Assert.NotNull(exception);
+            That(exception!.Message, Does.StartWith("Cannot get engine: default_Engine from testdb.ib database"));
         }
 
         [Test]
@@ -93,8 +94,9 @@ namespace FireboltDotNetSdk.Tests
         {
             const string connectionString = "database=testdb.ib;username=testuser;password=;account=accountname;endpoint=endpoint";
             var cs = new FireboltConnection(connectionString);
-            FireboltException exception = ThrowsAsync<FireboltException>(() => cs.OpenAsync());
-            That(exception.Message, Is.EqualTo("Password parameter is missing in the connection string"));
+            FireboltException? exception = ThrowsAsync<FireboltException>(() => cs.OpenAsync());
+            Assert.NotNull(exception);
+            That(exception!.Message, Is.EqualTo("Password parameter is missing in the connection string"));
         }
 
         [Test]
@@ -111,8 +113,9 @@ namespace FireboltDotNetSdk.Tests
         {
             const string connectionString = "database=testdb.ib;username=testuser;password=password;account=accountname;endpoint=endpoint";
             var cs = new FireboltConnection(connectionString);
-            InvalidOperationException exception = ThrowsAsync<InvalidOperationException>(() => cs.OpenAsync());
-            That(exception.Message, Is.EqualTo("An invalid request URI was provided. Either the request URI must be an absolute URI or BaseAddress must be set."));
+            InvalidOperationException? exception = ThrowsAsync<InvalidOperationException>(() => cs.OpenAsync());
+            Assert.NotNull(exception);
+            That(exception!.Message, Is.EqualTo("An invalid request URI was provided. Either the request URI must be an absolute URI or BaseAddress must be set."));
         }
 
         [Test]
@@ -120,8 +123,9 @@ namespace FireboltDotNetSdk.Tests
         {
             const string connectionString = "database=testdb.ib;username=testuser;password=passwordtest;account=accountname;endpoint=endpoint";
             var cs = new FireboltConnection(connectionString);
-            InvalidOperationException exception = Throws<InvalidOperationException>(() => cs.Open());
-            That(exception.Message, Is.EqualTo("An invalid request URI was provided. Either the request URI must be an absolute URI or BaseAddress must be set."));
+            InvalidOperationException? exception = Throws<InvalidOperationException>(() => cs.Open());
+            Assert.NotNull(exception);
+            That(exception!.Message, Is.EqualTo("An invalid request URI was provided. Either the request URI must be an absolute URI or BaseAddress must be set."));
         }
 
         [Test]

--- a/FireboltDotNetSdk.Tests/Unit/FireboltExceptionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltExceptionTest.cs
@@ -10,8 +10,9 @@ public class FireboltExceptionTest
     public void ThrowExceptionWithStatusCodeInternalServerError()
     {
 
-        FireboltException exception = Assert.Throws<FireboltException>(() => throw new FireboltException(HttpStatusCode.InternalServerError, "my error message from the server"));
-        Assert.That(exception.Message, Is.EqualTo("Received an unexpected status code from the server\nStatus: 500\nResponse:\nmy error message from the server"));
+        FireboltException? exception = Assert.Throws<FireboltException>(() => throw new FireboltException(HttpStatusCode.InternalServerError, "my error message from the server"));
+        Assert.NotNull(exception);
+        Assert.That(exception!.Message, Is.EqualTo("Received an unexpected status code from the server\nStatus: 500\nResponse:\nmy error message from the server"));
         Assert.That(exception.ToString(), Does.Contain("HTTP Response: my error message from the server\nFireboltDotNetSdk.Exception.FireboltException: Received an unexpected status code from the server"));
     }
 
@@ -19,16 +20,18 @@ public class FireboltExceptionTest
     [Test]
     public void ThrowExceptionWithStatusCodeInternalServerErrorWithoutServerResponse()
     {
-        FireboltException exception = Assert.Throws<FireboltException>(() => throw new FireboltException(HttpStatusCode.InternalServerError, null));
-        Assert.That(exception.Message, Is.EqualTo("Received an unexpected status code from the server\nStatus: 500"));
+        FireboltException? exception = Assert.Throws<FireboltException>(() => throw new FireboltException(HttpStatusCode.InternalServerError, null));
+        Assert.NotNull(exception);
+        Assert.That(exception!.Message, Is.EqualTo("Received an unexpected status code from the server\nStatus: 500"));
         Assert.That(exception.ToString(), Does.Contain("FireboltDotNetSdk.Exception.FireboltException: Received an unexpected status code from the server"));
     }
 
     [Test]
     public void ThrowExceptionWithStatusCodeUnauthorized()
     {
-        FireboltException exception = Assert.Throws<FireboltException>(() => throw new FireboltException(HttpStatusCode.Unauthorized, "my error message from the server"));
-        Assert.That(exception.Message, Is.EqualTo("The operation is unauthorized\nStatus: 401\nResponse:\nmy error message from the server"));
+        FireboltException? exception = Assert.Throws<FireboltException>(() => throw new FireboltException(HttpStatusCode.Unauthorized, "my error message from the server"));
+        Assert.NotNull(exception);
+        Assert.That(exception!.Message, Is.EqualTo("The operation is unauthorized\nStatus: 401\nResponse:\nmy error message from the server"));
         Assert.That(exception.ToString(), Does.Contain("HTTP Response: my error message from the server\nFireboltDotNetSdk.Exception.FireboltException: The operation is unauthorized"));
     }
 
@@ -36,16 +39,18 @@ public class FireboltExceptionTest
     public void ThrowExceptionWithStatusCodeForbidden()
     {
 
-        FireboltException exception = Assert.Throws<FireboltException>(() => throw new FireboltException(HttpStatusCode.Forbidden, "my error message from the server"));
-        Assert.That(exception.Message, Is.EqualTo("The operation is forbidden\nStatus: 403\nResponse:\nmy error message from the server"));
+        FireboltException? exception = Assert.Throws<FireboltException>(() => throw new FireboltException(HttpStatusCode.Forbidden, "my error message from the server"));
+        Assert.NotNull(exception);
+        Assert.That(exception!.Message, Is.EqualTo("The operation is forbidden\nStatus: 403\nResponse:\nmy error message from the server"));
         Assert.That(exception.ToString(), Does.Contain("HTTP Response: my error message from the server\nFireboltDotNetSdk.Exception.FireboltException: The operation is forbidden"));
     }
 
     [Test]
     public void ThrowExceptionWithoutStatusCode()
     {
-        FireboltException exception = Assert.Throws<FireboltException>(() => throw new FireboltException("An error happened"));
-        Assert.That(exception.Message, Is.EqualTo("An error happened"));
+        FireboltException? exception = Assert.Throws<FireboltException>(() => throw new FireboltException("An error happened"));
+        Assert.NotNull(exception);
+        Assert.That(exception!.Message, Is.EqualTo("An error happened"));
         Assert.That(exception.ToString(), Does.Not.Contain("HTTP Response:"));
     }
 

--- a/FireboltDotNetSdk.Tests/Unit/HttpClientSingletonTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/HttpClientSingletonTest.cs
@@ -14,6 +14,6 @@ public class HttpClientSingletonTest
     public void SetDefaultRequestHeaders()
     {
         HttpClient client = HttpClientSingleton.GetInstance();
-        Assert.That(client.DefaultRequestHeaders.UserAgent.ToList()[0].Product.Name, Is.EqualTo(".NETSDK"));
+        Assert.That(client.DefaultRequestHeaders.UserAgent.ToList()[0].Product?.Name, Is.EqualTo(".NETSDK"));
     }
 }

--- a/FireboltDotNetSdk.Tests/Unit/TypesConverterTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/TypesConverterTest.cs
@@ -126,7 +126,7 @@ public class TypesConverterTest
     {
         ColumnType columnType = ColumnType.Of("ByteA");
         var expectedBytes = Encoding.ASCII.GetBytes("hello_world_123");
-        object result = TypesConverter.ConvertToCSharpVal("\\x68656c6c6f5f776f726c645f313233", columnType);
+        object? result = TypesConverter.ConvertToCSharpVal("\\x68656c6c6f5f776f726c645f313233", columnType);
         Assert.That(result, Is.EqualTo(expectedBytes));
     }
 

--- a/FireboltDotNetSdk.Tests/Unit/TypesConverterTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/TypesConverterTest.cs
@@ -30,7 +30,7 @@ public class TypesConverterTest
     public void ConvertProvidedValues(String columnTypeName, string value, object expectedValue)
     {
         ColumnType columnType = ColumnType.Of(columnTypeName);
-        object result = TypesConverter.ConvertToCSharpVal(value, columnType);
+        object? result = TypesConverter.ConvertToCSharpVal(value, columnType);
         Assert.That(expectedValue, Is.EqualTo(result));
     }
 
@@ -40,7 +40,7 @@ public class TypesConverterTest
         ColumnType columnType = ColumnType.Of("TimestampTz");
         var value = "2022-05-10 21:01:02.12345+00";
         DateTime expectedValue = DateTime.Parse("2022-05-10 21:01:02.12345+00");
-        object result = TypesConverter.ConvertToCSharpVal(value, columnType);
+        object? result = TypesConverter.ConvertToCSharpVal(value, columnType);
         Assert.That(expectedValue, Is.EqualTo(result));
     }
 
@@ -51,7 +51,7 @@ public class TypesConverterTest
         var value = "2022-05-10 23:01:02.123456";
         DateTime expectedValue = new DateTime(2022, 5, 10, 23, 1, 2, 0);
         expectedValue = expectedValue.AddTicks(1234560);
-        object result = TypesConverter.ConvertToCSharpVal(value, columnType);
+        object? result = TypesConverter.ConvertToCSharpVal(value, columnType);
         Assert.That(result, Is.EqualTo(expectedValue));
     }
 
@@ -63,7 +63,7 @@ public class TypesConverterTest
     {
         ColumnType columnType = ColumnType.Of(type);
         var value = "2022-05-10";
-        object result = TypesConverter.ConvertToCSharpVal(value, columnType);
+        object? result = TypesConverter.ConvertToCSharpVal(value, columnType);
         DateOnly expectedDate = DateOnly.FromDateTime(new DateTime(2022, 5, 10, 23, 1, 2, 0));
         Assert.That(result, Is.EqualTo(expectedDate));
     }
@@ -73,17 +73,19 @@ public class TypesConverterTest
     {
         ColumnType columnType = ColumnType.Of("integer");
         var value = "hello";
-        FireboltException exception = Assert.Throws<FireboltException>(() => TypesConverter.ConvertToCSharpVal(value, columnType));
-        Assert.That(exception.Message, Is.EqualTo("Error converting hello to Int"));
-        Assert.That(exception.InnerException.GetType(), Is.EqualTo(typeof(FormatException)));
+        FireboltException? exception = Assert.Throws<FireboltException>(() => TypesConverter.ConvertToCSharpVal(value, columnType));
+        Assert.NotNull(exception);
+        Assert.That(exception!.Message, Is.EqualTo("Error converting hello to Int"));
+        Assert.NotNull(exception?.InnerException);
+        Assert.That(exception!.InnerException!.GetType(), Is.EqualTo(typeof(FormatException)));
     }
 
     [Test]
     public void ParseJsonResponseWithNullResponse()
     {
-        FireboltException exception =
+        FireboltException? exception =
             Assert.Throws<FireboltException>(() => TypesConverter.ParseJsonResponse(null));
-        Assert.That(exception.Message, Is.EqualTo("JSON data is missing"));
+        Assert.That(exception?.Message, Is.EqualTo("JSON data is missing"));
     }
 
     [Test]
@@ -93,7 +95,7 @@ public class TypesConverterTest
                 "{\"query\":{\"query_id\": \"174005F13D908A5D\"},\"meta\":[{\"name\": \"uint8\",\"type\": \"int\"},{\"name\": \"int_8\",\"type\": \"int\"},{\"name\": \"uint16\",\"type\": \"int\"},{\"name\": \"int16\",\"type\": \"int\"},{\"name\": \"uint32\",\"type\": \"int\"},{\"name\": \"int32\",\"type\": \"int\"},{\"name\": \"uint64\",\"type\": \"long\"},{\"name\": \"int64\",\"type\": \"long\"},{\"name\": \"float32\",\"type\": \"float\"},{\"name\": \"float64\",\"type\": \"double\"},{\"name\": \"string\",\"type\": \"text\"},{\"name\": \"date\",\"type\": \"date\"},{\"name\": \"array\",\"type\": \"array(int)\"},{\"name\": \"decimal\",\"type\": \"Decimal(38, 30)\"},{\"name\": \"nullable\",\"type\": \"int null\"}],\"data\":[[1, -1, 257, -257, 80000, -80000, 30000000000, -30000000000, 1.23, 1.23456789012, \"text\", \"2021-03-28\", [1,2,3,4], 1231232.123459999990457054844258706536, null]],\"rows\": 1,\"statistics\":{\"elapsed\": 0.001662899,\"rows_read\": 1,\"bytes_read\": 1,\"time_before_execution\": 0.001246457,\"time_to_execute\": 0.000166576,\"scanned_bytes_cache\": 0,\"scanned_bytes_storage\": 0}}"
             ;
         var res = TypesConverter.ParseJsonResponse(responseWithNewTypes).GetEnumerator();
-        object[] expected =
+        object?[] expected =
         {
             1, -1, 257, -257, 80000, -80000, 30000000000, -30000000000, 1.23f, 1.23456789012, "text",
             DateOnly.Parse("2021-03-28"), new [] { 1, 2, 3, 4 }, 1231232.123459999990457054844258706536, null
@@ -112,9 +114,11 @@ public class TypesConverterTest
     public void InvalidResponseParsingTest()
     {
         var responseWithNewTypes = "invalid response";
-        FireboltException exception = Assert.Throws<FireboltException>(() => TypesConverter.ParseJsonResponse(responseWithNewTypes));
-        Assert.IsTrue(exception.Message.Contains("Error while parsing response"));
-        Assert.That(exception.InnerException.GetType(), Is.EqualTo(typeof(JsonReaderException)));
+        FireboltException? exception = Assert.Throws<FireboltException>(() => TypesConverter.ParseJsonResponse(responseWithNewTypes));
+        Assert.NotNull(exception);
+        Assert.IsTrue(exception!.Message.Contains("Error while parsing response"));
+        Assert.NotNull(exception.InnerException);
+        Assert.That(exception!.InnerException!.GetType(), Is.EqualTo(typeof(JsonReaderException)));
     }
 
     [Test]

--- a/FireboltNETSDK/Client/FireResponse.cs
+++ b/FireboltNETSDK/Client/FireResponse.cs
@@ -21,7 +21,8 @@ namespace FireboltDotNetSdk.Client
     {
         public class LoginResponse
         {
-            internal LoginResponse(string access_token, string expires_in, string refresh_token, string token_type) {
+            internal LoginResponse(string access_token, string expires_in, string refresh_token, string token_type)
+            {
                 Access_token = access_token;
                 Expires_in = expires_in;
                 Refresh_token = refresh_token;

--- a/FireboltNETSDK/Client/FireResponse.cs
+++ b/FireboltNETSDK/Client/FireResponse.cs
@@ -21,10 +21,16 @@ namespace FireboltDotNetSdk.Client
     {
         public class LoginResponse
         {
+            internal LoginResponse(string access_token, string expires_in, string refresh_token, string token_type) {
+                Access_token = access_token;
+                Expires_in = expires_in;
+                Refresh_token = refresh_token;
+                Token_type = token_type;
+            }
             /// <summary>
             /// Access token.
             /// </summary>
-            public string? Access_token { get; set; }
+            public string Access_token { get; set; }
 
             /// <summary>
             /// Number of seconds after which token will expire.
@@ -74,7 +80,7 @@ namespace FireboltDotNetSdk.Client
             /// <summary>
             /// Retrieved record.
             /// </summary>
-            public Engine engine_id { get; set; }
+            public Engine? engine_id { get; set; }
 
         }
 

--- a/FireboltNETSDK/Client/FireResponse.cs
+++ b/FireboltNETSDK/Client/FireResponse.cs
@@ -21,7 +21,7 @@ namespace FireboltDotNetSdk.Client
     {
         public class LoginResponse
         {
-            internal LoginResponse(string access_token, string expires_in, string refresh_token, string token_type)
+            public LoginResponse(string access_token, string expires_in, string refresh_token, string token_type)
             {
                 Access_token = access_token;
                 Expires_in = expires_in;

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -116,7 +116,7 @@ namespace FireboltDotNetSdk.Client
         internal FireboltCommand(FireboltConnection connection) =>
             Connection = connection ?? throw new ArgumentNullException(nameof(connection));
 
-        public QueryResult Execute(string commandText)
+        public QueryResult? Execute(string commandText)
         {
             var engineUrl = Connection?.Engine?.engine?.endpoint ?? Connection?.DefaultEngine?.Engine_url;
             if (commandText.Trim().StartsWith("SET"))
@@ -131,13 +131,15 @@ namespace FireboltDotNetSdk.Client
                 newCommandText = GetParamQuery(commandText);
             }
 
-            if (Connection != null)
+            if (Connection != null && Connection.Client != null)
             {
                 Response = Connection.Client
                     .ExecuteQuery(engineUrl, Connection.Database, SetParamList, newCommandText)
                     .GetAwaiter().GetResult();
-                //return FormDataForResponse(Response); 
+            } else {
+                throw new NullReferenceException("Client is not initialised to perform the operation. Make sure the connection is open.");
             }
+
             return GetOriginalJsonData();
         }
 

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -80,6 +80,7 @@ namespace FireboltDotNetSdk.Client
 
         public override string DataSource => throw new NotImplementedException();
 
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public override string ConnectionString { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         /// <summary>
@@ -203,6 +204,9 @@ namespace FireboltDotNetSdk.Client
                 .GetEngineUrlByEngineName(engineName, _connectionState.Settings?.Account)
                 .GetAwaiter()
                 .GetResult();
+            if (enginevalue.engine_id == null) {
+                throw new FireboltException($"Cannot find an engine with name: {engineName}");
+            }
             var result = Client.GetEngineUrlByEngineId(enginevalue.engine_id.engine_id,
                     enginevalue.engine_id.account_id).GetAwaiter()
                 .GetResult();

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -169,9 +169,7 @@ namespace FireboltDotNetSdk.Client
 
         public GetEngineUrlByDatabaseNameResponse? SetDefaultEngine(string? engineName)
         {
-            if (Client is null) {
-                throw new NullReferenceException("Client is not initialised to perform the operation. Make sure the connection is open.");
-            }
+            if (Client is null) throw new NullReferenceException("Client is not initialised to perform the operation. Make sure the connection is open.");
             try
             {
                 DefaultEngine = Client
@@ -195,7 +193,8 @@ namespace FireboltDotNetSdk.Client
 
         public GetEngineUrlByEngineNameResponse SetEngine(string engineName)
         {
-            if (Client is null) {
+            if (Client is null)
+            {
                 throw new NullReferenceException("Client is not initialised to perform the operation. Make sure the connection is open.");
             }
             // try
@@ -204,7 +203,8 @@ namespace FireboltDotNetSdk.Client
                 .GetEngineUrlByEngineName(engineName, _connectionState.Settings?.Account)
                 .GetAwaiter()
                 .GetResult();
-            if (enginevalue.engine_id == null) {
+            if (enginevalue.engine_id == null)
+            {
                 throw new FireboltException($"Cannot find an engine with name: {engineName}");
             }
             var result = Client.GetEngineUrlByEngineId(enginevalue.engine_id.engine_id,

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -193,10 +193,7 @@ namespace FireboltDotNetSdk.Client
 
         public GetEngineUrlByEngineNameResponse SetEngine(string engineName)
         {
-            if (Client is null)
-            {
-                throw new NullReferenceException("Client is not initialised to perform the operation. Make sure the connection is open.");
-            }
+            if (Client is null) throw new NullReferenceException("Client is not initialised to perform the operation. Make sure the connection is open.");
             // try
             // {
             var enginevalue = Client

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -168,6 +168,9 @@ namespace FireboltDotNetSdk.Client
 
         public GetEngineUrlByDatabaseNameResponse? SetDefaultEngine(string? engineName)
         {
+            if (Client is null) {
+                throw new NullReferenceException("Client is not initialised to perform the operation. Make sure the connection is open.");
+            }
             try
             {
                 DefaultEngine = Client
@@ -189,8 +192,11 @@ namespace FireboltDotNetSdk.Client
             }
         }
 
-        public GetEngineUrlByEngineNameResponse SetEngine(string? engineName)
+        public GetEngineUrlByEngineNameResponse SetEngine(string engineName)
         {
+            if (Client is null) {
+                throw new NullReferenceException("Client is not initialised to perform the operation. Make sure the connection is open.");
+            }
             // try
             // {
             var enginevalue = Client

--- a/FireboltNETSDK/Client/FireboltParameter.cs
+++ b/FireboltNETSDK/Client/FireboltParameter.cs
@@ -39,9 +39,9 @@ namespace FireboltDotNetSdk.Client
         /// Gets or sets the <see cref="FireboltDbType"/> of the parameter.
         /// </summary>
         /// <returns>One of the <see cref="FireboltDbType"/> values. The default value is defined based on the type of the parameter's value.</returns>
-        public FireboltDbType FireboltDbType
+        public FireboltDbType? FireboltDbType
         {
-            get => (FireboltDbType)_forcedType;
+            get => _forcedType;
             set => _forcedType = value;
         }
 
@@ -56,7 +56,8 @@ namespace FireboltDotNetSdk.Client
         {
             get
             {
-                var chType = FireboltDbType;
+                // not sure if this is right
+                var chType = FireboltDbType ?? global::FireboltDbType.String;
                 return (DbType)chType;
             }
             set => FireboltDbType = (FireboltDbType)value;

--- a/FireboltNETSDK/Client/FireboltParameter.cs
+++ b/FireboltNETSDK/Client/FireboltParameter.cs
@@ -56,7 +56,6 @@ namespace FireboltDotNetSdk.Client
         {
             get
             {
-                // not sure if this is right
                 var chType = FireboltDbType ?? global::FireboltDbType.String;
                 return (DbType)chType;
             }

--- a/FireboltNETSDK/FireboltClient.cs
+++ b/FireboltNETSDK/FireboltClient.cs
@@ -107,7 +107,7 @@ public class FireboltClient
     /// <param name="engineId">Name of the database.</param>
     /// <param name="accountId"></param>
     /// <returns>An Engine url response.</returns>
-    public Task<GetEngineUrlByEngineNameResponse> GetEngineUrlByEngineId(string engineId, string accountId)
+    public Task<GetEngineUrlByEngineNameResponse> GetEngineUrlByEngineId(string? engineId, string? accountId)
     {
         return CoreV1GetEngineUrlByEngineIdAsync(engineId, accountId, CancellationToken.None);
     }
@@ -221,7 +221,7 @@ public class FireboltClient
     /// </summary>
     /// <returns>A successful response.</returns>
     /// <exception cref="FireboltException">A server side error occurred.</exception>
-    public async Task<GetAccountIdByNameResponse> GetAccountIdByNameAsync(string account,
+    public async Task<GetAccountIdByNameResponse> GetAccountIdByNameAsync(string? account,
         CancellationToken cancellationToken)
     {
         if (account == null) throw new FireboltException("Account name is empty");
@@ -235,10 +235,11 @@ public class FireboltClient
         return await SendAsync<GetAccountIdByNameResponse>(HttpMethod.Get, urlBuilder.ToString(), (string?)null, true, cancellationToken);
     }
 
-    private async Task<GetEngineUrlByEngineNameResponse> CoreV1GetEngineUrlByEngineIdAsync(string engineId,
-        string accountId, CancellationToken cancellationToken)
+    private async Task<GetEngineUrlByEngineNameResponse> CoreV1GetEngineUrlByEngineIdAsync(string? engineId,
+        string? accountId, CancellationToken cancellationToken)
     {
         if (engineId == null) throw new FireboltException("Engine name is incorrect or missing");
+        if (accountId == null) throw new FireboltException("Account id is incorrect or missing");
 
         var urlBuilder = new StringBuilder();
         urlBuilder.Append(_endpoint).Append("/core/v1/accounts/" + accountId + "/engines/" + engineId);
@@ -441,11 +442,10 @@ public class FireboltClient
         var storedToken = await TokenSecureStorage.GetCachedToken(_username, _password);
         if (storedToken != null)
         {
-            token = new LoginResponse
-            {
-                Access_token = storedToken.token,
-                Expires_in = storedToken.expiration.ToString()
-            };
+            token = new LoginResponse(access_token: storedToken.token,
+                expires_in: storedToken.expiration.ToString(),
+                refresh_token: "",
+                token_type: "");
         }
         else
         {

--- a/FireboltNETSDK/Utils/ArrayHelper.cs
+++ b/FireboltNETSDK/Utils/ArrayHelper.cs
@@ -47,9 +47,11 @@ public class ArrayHelper
         var elements = SplitArrayContent(arrayContent)
             .Where(x => !string.IsNullOrEmpty(x)).Select(x => RemoveQuotesAndTransformNull(x)).ToList();
         Array currentArray = new dynamic[elements.Count];
-        for (int i = 0; i < elements.Count; i++) {
+        for (int i = 0; i < elements.Count; i++)
+        {
             var innerType = columnType.GetArrayBaseColumnType();
-            if (innerType == null) {
+            if (innerType == null)
+            {
                 throw new FireboltException("Unable to retrieve a Firebolt type of an array");
             }
             currentArray.SetValue(TypesConverter.ConvertToCSharpVal(elements[i], innerType), i);

--- a/FireboltNETSDK/Utils/ArrayHelper.cs
+++ b/FireboltNETSDK/Utils/ArrayHelper.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using FireboltDoNetSdk.Utils;
+using FireboltDotNetSdk.Exception;
 
 namespace FireboltDotNetSdk.Utils;
 
@@ -46,9 +47,14 @@ public class ArrayHelper
         var elements = SplitArrayContent(arrayContent)
             .Where(x => !string.IsNullOrEmpty(x)).Select(x => RemoveQuotesAndTransformNull(x)).ToList();
         Array currentArray = new dynamic[elements.Count];
-        for (int i = 0; i < elements.Count; i++)
-            currentArray.SetValue(TypesConverter.ConvertToCSharpVal(elements[i], columnType.GetArrayBaseColumnType()),
-                i);
+        for (int i = 0; i < elements.Count; i++) {
+            var innerType = columnType.GetArrayBaseColumnType();
+            if (innerType == null) {
+                throw new FireboltException("Unable to retrieve a Firebolt type of an array");
+            }
+            currentArray.SetValue(TypesConverter.ConvertToCSharpVal(elements[i], innerType), i);
+
+        }
         return currentArray;
     }
 

--- a/FireboltNETSDK/Utils/JsonHelper.cs
+++ b/FireboltNETSDK/Utils/JsonHelper.cs
@@ -5,34 +5,34 @@ namespace FireboltDotNetSdk.Utils
     public class QueryResult
     {
         [JsonProperty("query", NullValueHandling = NullValueHandling.Ignore)]
-        public Query Query { get; set; }
+        public Query Query { get; set; } = null!;
 
         [JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)]
-        public List<Meta> Meta { get; set; }
+        public List<Meta> Meta { get; set; } = null!;
 
         [JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
-        public List<List<object?>> Data { get; set; }
+        public List<List<object?>> Data { get; set; } = null!;
 
         [JsonProperty("rows", NullValueHandling = NullValueHandling.Ignore)]
         public long? Rows { get; set; }
 
         [JsonProperty("statistics", NullValueHandling = NullValueHandling.Ignore)]
-        public Statistics Statistics { get; set; }
+        public Statistics Statistics { get; set; } = null!;
     }
 
     public class Meta
     {
         [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
-        public string Type { get; set; }
+        public string Type { get; set; } = null!;
     }
 
     public class Query
     {
         [JsonProperty("query_id", NullValueHandling = NullValueHandling.Ignore)]
-        public string QueryId { get; set; }
+        public string QueryId { get; set; } = null!;
     }
 
     public class Statistics

--- a/FireboltNETSDK/Utils/TokenSecureStorage.cs
+++ b/FireboltNETSDK/Utils/TokenSecureStorage.cs
@@ -57,12 +57,11 @@ namespace FireboltDotNetSdk.Utils
                 var b64decoded = WebEncoders.Base64UrlDecode(raw_data.token);
                 var token = (new FernetEncryptor(username + password, raw_data.salt)).Decrypt(b64decoded);
 
-                CachedJSONData data = new()
-                {
-                    token = token,
-                    salt = raw_data.salt,
-                    expiration = Convert.ToInt32(raw_data.expiration)
-                };
+                CachedJSONData data = new(
+                    paramToken: token,
+                    paramSalt: raw_data.salt,
+                    paramExpiration: Convert.ToInt32(raw_data.expiration)
+                );
                 if (data.expiration < Convert.ToInt32(new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds()))
                 {
                     // Token has expired, returning null
@@ -85,12 +84,11 @@ namespace FireboltDotNetSdk.Utils
             {
                 var encryptor = new FernetEncryptor(username + password);
                 var token = encryptor.Encrypt(tokenData.Access_token);
-                CachedJSONData data = new()
-                {
-                    token = WebEncoders.Base64UrlEncode(token),
-                    salt = encryptor.salt,
-                    expiration = Convert.ToInt32(tokenData.Expires_in) + Convert.ToInt32(new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds())
-                };
+                CachedJSONData data = new(
+                    paramToken: WebEncoders.Base64UrlEncode(token),
+                    paramSalt: encryptor.salt,
+                    paramExpiration: Convert.ToInt32(tokenData.Expires_in) + Convert.ToInt32(new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds())
+                );
 
                 var cacheDir = GetCacheDir();
                 if (!Directory.Exists(cacheDir))
@@ -133,6 +131,11 @@ namespace FireboltDotNetSdk.Utils
 
     public class CachedJSONData
     {
+        public CachedJSONData(string paramToken, string paramSalt, int paramExpiration){
+            token = paramToken;
+            salt = paramSalt;
+            expiration = paramExpiration;
+        }
         public string token { get; set; }
         public string salt { get; set; }
         public int expiration { get; set; }

--- a/FireboltNETSDK/Utils/TokenSecureStorage.cs
+++ b/FireboltNETSDK/Utils/TokenSecureStorage.cs
@@ -131,7 +131,8 @@ namespace FireboltDotNetSdk.Utils
 
     public class CachedJSONData
     {
-        public CachedJSONData(string paramToken, string paramSalt, int paramExpiration){
+        public CachedJSONData(string paramToken, string paramSalt, int paramExpiration)
+        {
             token = paramToken;
             salt = paramSalt;
             expiration = paramExpiration;

--- a/FireboltNETSDK/Utils/Types.cs
+++ b/FireboltNETSDK/Utils/Types.cs
@@ -357,7 +357,8 @@ namespace FireboltDoNetSdk.Utils
 }
 public class NewMeta
 {
-    public NewMeta (ArrayList data, string meta) {
+    public NewMeta(ArrayList data, string meta)
+    {
         Data = data;
         Meta = meta;
     }

--- a/FireboltNETSDK/Utils/Types.cs
+++ b/FireboltNETSDK/Utils/Types.cs
@@ -321,7 +321,7 @@ namespace FireboltDoNetSdk.Utils
             return type;
         }
 
-        public static IEnumerable<NewMeta> ParseJsonResponse(string response)
+        public static IEnumerable<NewMeta> ParseJsonResponse(string? response)
         {
             if (response == null)
             {
@@ -331,19 +331,20 @@ namespace FireboltDoNetSdk.Utils
             {
                 var prettyJson = JToken.Parse(response).ToString(Formatting.Indented);
                 var data = JsonConvert.DeserializeObject<QueryResult>(prettyJson);
+                if (data == null) throw new FireboltException("Unable to parse data to JSON");
                 var newListData = new List<NewMeta>();
                 foreach (var t in data.Data)
                     for (var j = 0; j < t.Count; j++)
                     {
                         var columnType = ColumnType.Of(TypesConverter.GetFullColumnTypeName(data.Meta[j]));
                         newListData.Add(new NewMeta
-                        {
-                            Data = new ArrayList
+                        (
+                            data: new ArrayList
                             {
                                 TypesConverter.ConvertToCSharpVal(t[j]?.ToString(), columnType)
                             },
-                            Meta = columnType.Type.ToString()
-                        });
+                            meta: columnType.Type.ToString()
+                        ));
                     }
                 return newListData;
             }
@@ -356,6 +357,10 @@ namespace FireboltDoNetSdk.Utils
 }
 public class NewMeta
 {
+    public NewMeta (ArrayList data, string meta) {
+        Data = data;
+        Meta = meta;
+    }
     public ArrayList Data { get; set; }
     public string Meta { get; set; }
 }


### PR DESCRIPTION
Eliminating nullability compiler warnings by clarifying it throughout the code.

Main assumptions here:
* Better throw exception with descriptive type/message when unexpected null is encountered than forcing or assuming it won't happen.
* In tests we first check if nullable attribute is not null until checksing sub-attributes. While notnull assert is not blocking (other asserts will also evaluate) it will be the first one to error out, therefore indicating the actual error a bit more accurately.
* rowCount will return -1 if data does not contain it. This is consistent with the Python SDK.
* AesManaged is deprecated in favour of equivalent Aes.Create()

Tests are passing.