### PR TITLE
feat(FIR-16885): Move engine setting to connection string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Build project
       id: build
       run: |
-        dotnet build /warnaserror
+        dotnet build

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,6 +85,5 @@ jobs:
           FIREBOLT_ENDPOINT: "https://api.${{ inputs.environment }}.firebolt.io"
           ACCOUNT_NAME: "firebolt"
           FIREBOLT_ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
-          FIREBOLT_ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
         run: |
           dotnet test --filter "Category=Integration"        

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,5 +85,6 @@ jobs:
           FIREBOLT_ENDPOINT: "https://api.${{ inputs.environment }}.firebolt.io"
           ACCOUNT_NAME: "firebolt"
           FIREBOLT_ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
+          FIREBOLT_ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
         run: |
           dotnet test --filter "Category=Integration"        

--- a/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
+++ b/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
@@ -9,7 +9,7 @@
     <AltCoverAssemblyFilter>?FireboltDotNetSdk;FireboltDotNetSdk.Tests</AltCoverAssemblyFilter>
     <AltCoverTypeFilter>Microsoft;System;/</AltCoverTypeFilter>
     <AltCoverCobertura>coverage.xml</AltCoverCobertura>
-
+    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
+++ b/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
@@ -9,6 +9,7 @@
     <AltCoverAssemblyFilter>?FireboltDotNetSdk;FireboltDotNetSdk.Tests</AltCoverAssemblyFilter>
     <AltCoverTypeFilter>Microsoft;System;/</AltCoverTypeFilter>
     <AltCoverCobertura>coverage.xml</AltCoverCobertura>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
+++ b/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
@@ -10,6 +10,7 @@
     <AltCoverTypeFilter>Microsoft;System;/</AltCoverTypeFilter>
     <AltCoverCobertura>coverage.xml</AltCoverCobertura>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
+++ b/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
@@ -9,7 +9,6 @@
     <AltCoverAssemblyFilter>?FireboltDotNetSdk;FireboltDotNetSdk.Tests</AltCoverAssemblyFilter>
     <AltCoverTypeFilter>Microsoft;System;/</AltCoverTypeFilter>
     <AltCoverCobertura>coverage.xml</AltCoverCobertura>
-    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
+++ b/FireboltDotNetSdk.Tests/FireboltDotNetSdk.Tests.csproj
@@ -11,6 +11,7 @@
     <AltCoverCobertura>coverage.xml</AltCoverCobertura>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
+    <NoWarn>612,618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -280,7 +280,7 @@ namespace FireboltDotNetSdk.Tests
             FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
             Assert.That(exception!.Message, Is.EqualTo("Cannot get engine url for InexistantEngine engine from Aymeric_test database"));
         }
-        
+
         [Test]
         public void ShouldExecuteUsingEngineUrl()
         {

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -278,7 +278,7 @@ namespace FireboltDotNetSdk.Tests
                 $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name=InexistantEngine";
             using var conn = new FireboltConnection(connString);
             FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
-            Assert.That(exception!.Message, Is.EqualTo("Cannot get engine url for InexistantEngine engine from Aymeric_test database"));
+            Assert.That(exception!.Message, Is.EqualTo($"Cannot get engine url for InexistantEngine engine from {Database} database"));
         }
 
         [Test]

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -52,11 +52,10 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSetEngineTest(string commandText)
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
-            conn.SetEngine(Engine);
 
             var value = conn.CreateCursor().Execute(commandText);
             Assert.NotNull(value);
@@ -78,11 +77,10 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampNtz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
-            conn.SetEngine(Engine);
             var command = conn.CreateCursor();
             command.Execute("SELECT '2022-05-10 23:01:02.123455'::timestampntz");
             DateTime dt = new DateTime(2022, 5, 10, 23, 1, 2, 0).AddTicks(1234550);
@@ -96,11 +94,10 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampPgDate()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
-            conn.SetEngine(Engine);
             var command = conn.CreateCursor();
             command.Execute("SELECT '2022-05-10'::pgdate");
             DateTime dt = new DateTime(2022, 5, 10, 0, 0, 0);
@@ -114,11 +111,10 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampTz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
-            conn.SetEngine(Engine);
             var command = conn.CreateCursor();
             command.Execute("SELECT '2022-05-10 23:01:02.123456 Europe/Berlin'::timestamptz");
 
@@ -134,10 +130,9 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampTzWithMinutesInTz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
             using var conn = new FireboltConnection(connString);
             conn.Open();
-            conn.SetEngine(Engine);
             var command = conn.CreateCursor();
             command.Execute("SET advanced_mode=1");
             command.Execute("SET time_zone=Asia/Calcutta");
@@ -154,10 +149,9 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampTzWithTzWithMinutesAndSecondsInTz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
             using var conn = new FireboltConnection(connString);
             conn.Open();
-            conn.SetEngine(Engine);
             var command = conn.CreateCursor();
             command.Execute("SET advanced_mode=1");
             command.Execute("SET time_zone=Asia/Calcutta");
@@ -174,10 +168,9 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampTzWithTzWithDefaultTz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
             using var conn = new FireboltConnection(connString);
             conn.Open();
-            conn.SetEngine(Engine);
             var command = conn.CreateCursor();
             command.Execute("SELECT '2022-05-01 12:01:02.123456'::timestamptz");
 
@@ -192,11 +185,10 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectBoolean()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
-            conn.SetEngine(Engine);
             var command = conn.CreateCursor();
             command.Execute("SET advanced_mode=1");
             command.Execute("SET output_format_firebolt_type_names=true");
@@ -277,6 +269,29 @@ namespace FireboltDotNetSdk.Tests
             Assert.NotNull(command.Response == null);
             NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
             Assert.That(newMeta.Data[0], Is.EqualTo(Encoding.UTF8.GetBytes("hello_world_123ツ\n\u0048")));
+        }
+
+        [Test]
+        public void ShouldThrowExceptionWhenEngineIsNotFound()
+        {
+            var connString =
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name=InexistantEngine";
+            using var conn = new FireboltConnection(connString);
+            FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
+            Assert.That(exception!.Message, Is.EqualTo("Cannot get engine url for InexistantEngine engine from Aymeric_test database"));
+        }
+        
+        [Test]
+        public void ShouldExecuteUsingEngineUrl()
+        {
+            var connString =
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_url={EngineUrl}";
+            using var conn = new FireboltConnection(connString);
+            conn.Open();
+            var command = conn.CreateCursor();
+            command.Execute("SELECT 1");
+            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
+            Assert.That(newMeta.Data[0], Is.EqualTo(1));
         }
     }
 }

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -52,7 +52,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSetEngineTest(string commandText)
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
@@ -77,7 +77,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampNtz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
@@ -94,7 +94,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampPgDate()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
@@ -111,7 +111,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampTz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
@@ -130,7 +130,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampTzWithMinutesInTz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine={EngineName}";
             using var conn = new FireboltConnection(connString);
             conn.Open();
             var command = conn.CreateCursor();
@@ -149,7 +149,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampTzWithTzWithMinutesAndSecondsInTz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine={EngineName}";
             using var conn = new FireboltConnection(connString);
             conn.Open();
             var command = conn.CreateCursor();
@@ -168,7 +168,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectTimestampTzWithTzWithDefaultTz()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine={EngineName}";
             using var conn = new FireboltConnection(connString);
             conn.Open();
             var command = conn.CreateCursor();
@@ -185,7 +185,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectBoolean()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name={EngineName}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine={EngineName}";
 
             using var conn = new FireboltConnection(connString);
             conn.Open();
@@ -275,23 +275,45 @@ namespace FireboltDotNetSdk.Tests
         public void ShouldThrowExceptionWhenEngineIsNotFound()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_name=InexistantEngine";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine=InexistantEngine";
             using var conn = new FireboltConnection(connString);
             FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
             Assert.That(exception!.Message, Is.EqualTo($"Cannot get engine url for InexistantEngine engine from {Database} database"));
         }
 
         [Test]
-        public void ShouldExecuteUsingEngineUrl()
+        public void SetEngine()
         {
             var connString =
-                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};engine_url={EngineUrl}";
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};";
             using var conn = new FireboltConnection(connString);
             conn.Open();
+            conn.SetEngine(EngineName);
             var command = conn.CreateCursor();
-            command.Execute("SELECT 1");
-            NewMeta newMeta = ResponseUtilities.getFirstRow(command.Response!);
-            Assert.That(newMeta.Data[0], Is.EqualTo(1));
+            var value = command.Execute("SELECT 1");
+            Assert.NotNull(value);
+            Assert.That(value!.Data[0][0], Is.EqualTo(1));
+        }
+        [Test]
+        public void SetDefaultEngine()
+        {
+            var connString = $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};";
+            using var conn = new FireboltConnection(connString);
+            conn.Open();
+            conn.SetDefaultEngine();
+            var command = conn.CreateCursor();
+            var value = command.Execute("SELECT 1");
+            Assert.NotNull(value);
+            Assert.That(value!.Data[0][0], Is.EqualTo(1));
+        }
+        
+        [Test]
+        public void SetEngineThrowsExceptionIfConnectionNotOpened()
+        {
+            var connString =
+                $"database={Database};username={Username};password={Password};endpoint={Endpoint};account={Account};";
+            using var conn = new FireboltConnection(connString);
+            Assert.Throws<NullReferenceException>(() => conn.SetEngine(EngineName));
         }
     }
 }

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -306,7 +306,7 @@ namespace FireboltDotNetSdk.Tests
             Assert.NotNull(value);
             Assert.That(value!.Data[0][0], Is.EqualTo(1));
         }
-        
+
         [Test]
         public void SetEngineThrowsExceptionIfConnectionNotOpened()
         {

--- a/FireboltDotNetSdk.Tests/Integration/IntegrationTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/IntegrationTest.cs
@@ -27,7 +27,8 @@ namespace FireboltDotNetSdk.Tests
         protected static string Password = EnvWithDefault("FIREBOLT_PASSWORD");
         protected static string Endpoint = EnvWithDefault("FIREBOLT_ENDPOINT", "https://api.dev.firebolt.io");
         protected static string Account = EnvWithDefault("FIREBOLT_ACCOUNT", "firebolt");
-        protected static string Engine = EnvWithDefault("FIREBOLT_ENGINE_NAME");
+        protected static string EngineName = EnvWithDefault("FIREBOLT_ENGINE_NAME");
+        protected static string EngineUrl = EnvWithDefault("FIREBOLT_ENGINE_URL");
         protected static string ClientId = EnvWithDefault("FIREBOLT_CLIENT_ID");
         protected static string ClientSecret = EnvWithDefault("FIREBOLT_CLIENT_SECRET");
     }

--- a/FireboltDotNetSdk.Tests/Integration/IntegrationTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/IntegrationTest.cs
@@ -28,7 +28,6 @@ namespace FireboltDotNetSdk.Tests
         protected static string Endpoint = EnvWithDefault("FIREBOLT_ENDPOINT", "https://api.dev.firebolt.io");
         protected static string Account = EnvWithDefault("FIREBOLT_ACCOUNT", "firebolt");
         protected static string EngineName = EnvWithDefault("FIREBOLT_ENGINE_NAME");
-        protected static string EngineUrl = EnvWithDefault("FIREBOLT_ENGINE_URL");
         protected static string ClientId = EnvWithDefault("FIREBOLT_CLIENT_ID");
         protected static string ClientSecret = EnvWithDefault("FIREBOLT_CLIENT_SECRET");
     }

--- a/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
@@ -15,7 +15,7 @@ namespace FireboltDotNetSdk.Tests
         [OneTimeSetUp]
         public void Init()
         {
-            var connString = $"database={Database};username={Username};password={Password};endpoint={Endpoint};engine_name=system";
+            var connString = $"database={Database};username={Username};password={Password};endpoint={Endpoint};engine=system";
             Connection = new FireboltConnection(connString);
             Connection.Open();
             var cursor = Connection.CreateCursor();

--- a/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
@@ -15,7 +15,7 @@ namespace FireboltDotNetSdk.Tests
         [OneTimeSetUp]
         public void Init()
         {
-            var connString = $"database={Database};username={Username};password={Password};endpoint={Endpoint};engine=system";
+            var connString = $"database={Database};username={ClientId};password={ClientSecret};endpoint={Endpoint};engine=system";
             Connection = new FireboltConnection(connString);
             Connection.Open();
             var cursor = Connection.CreateCursor();

--- a/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
@@ -15,10 +15,9 @@ namespace FireboltDotNetSdk.Tests
         [OneTimeSetUp]
         public void Init()
         {
-            var connString = $"database={Database};username={Username};password={Password};endpoint={Endpoint};";
+            var connString = $"database={Database};username={Username};password={Password};endpoint={Endpoint};engine_name=system";
             Connection = new FireboltConnection(connString);
             Connection.Open();
-            Connection.SetEngine("system");
             var cursor = Connection.CreateCursor();
             CreateEngine(cursor, newEngineName, "SPEC = B1");
             CreateDatabase(cursor, newDatabaseName, newEngineName);

--- a/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
@@ -50,18 +50,6 @@ namespace FireboltDotNetSdk.Tests
         }
 
         [Test]
-        [Ignore("GetEngineUrlByEngineNameResponse does not throw the exception with this message for the moment")]
-        public void SetEngineTest()
-        {
-            const string connectionString = "database=testdb.ib;username=testuser;password=;account=accountname;endpoint=endpoint";
-            var cs = new FireboltConnection(connectionString);
-
-            FireboltException? exception = Throws<FireboltException>(() => cs.SetEngine("default_Engine"));
-            Assert.NotNull(exception);
-            That(exception!.Message, Does.StartWith("Cannot get engine: default_Engine from testdb.ib database"));
-        }
-
-        [Test]
         public void OnSessionEstablishedTest()
         {
             const string connectionString = "database=testdb.ib;username=testuser;password=;account=accountname;endpoint=endpoint";

--- a/FireboltNETSDK/Client/FireResponse.cs
+++ b/FireboltNETSDK/Client/FireResponse.cs
@@ -76,7 +76,7 @@ namespace FireboltDotNetSdk.Client
             public string? endpoint { get; set; }
         }
 
-        public class GetEngineNameByEngineIdResponse
+        public class GetEngineIdByEngineNameResponse
         {
             /// <summary>
             /// Retrieved record.

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -118,7 +118,7 @@ namespace FireboltDotNetSdk.Client
 
         public QueryResult? Execute(string commandText)
         {
-            var engineUrl = Connection?.Engine?.engine?.endpoint ?? Connection?.DefaultEngine?.Engine_url;
+            var engineUrl = Connection?.EngineUrl;
             if (commandText.Trim().StartsWith("SET"))
             {
                 commandText = commandText.Remove(0, 4).Trim();

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -207,6 +207,9 @@ namespace FireboltDotNetSdk.Client
             }
         }
 
+        /// <summary>
+        /// Set engineUrl to use the default engine of the database
+        /// </summary>
         [Obsolete("The default engine is used when the engine is not specified as part of the connection string")]
         public void SetDefaultEngine()
         {
@@ -214,6 +217,10 @@ namespace FireboltDotNetSdk.Client
             EngineUrl = GetDefaultEngineUrl(Client);
         }
 
+        /// <summary>
+        /// Set engineUrl to use the url of the engine provided
+        /// </summary>
+        /// <param name="engineName">The engine name.</param>
         [Obsolete("Pass engine as part of the connection string instead")]
         public void SetEngine(string engineName)
         {

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -31,30 +31,30 @@ namespace FireboltDotNetSdk.Client
     {
         private readonly FireboltConnectionState _connectionState;
 
-        public FireboltClient Client { get; private set; }
-        public string EngineUrl { get; private set; }
+        public FireboltClient? Client { get; private set; }
+        public string? EngineUrl { get; private set; }
 
         /// <summary>
         /// Gets the name of the database specified in the connection settings.
         /// </summary>
         /// <returns>The name of the database specified in the connection settings. The default value is an empty string.</returns>
-        public override string Database => _connectionState.Settings.Database ?? throw new FireboltException("Database is missing");
+        public override string Database => _connectionState.Settings?.Database ?? throw new FireboltException("Database is missing");
 
         public string Password
         {
-            get => _connectionState.Settings.Password ?? throw new FireboltException("Password parameter is missing in the connection string");
+            get => _connectionState.Settings?.Password ?? throw new FireboltException("Password parameter is missing in the connection string");
             set => throw new NotImplementedException();
         }
 
         public string Endpoint
         {
-            get => _connectionState.Settings.Endpoint ?? Constant.BaseUrl;
+            get => _connectionState.Settings?.Endpoint ?? Constant.BaseUrl;
             set => throw new NotImplementedException();
         }
 
         public string Account
         {
-            get => _connectionState.Settings.Account ?? string.Empty;
+            get => _connectionState.Settings?.Account ?? string.Empty;
             set => throw new NotImplementedException();
         }
 

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -31,30 +31,30 @@ namespace FireboltDotNetSdk.Client
     {
         private readonly FireboltConnectionState _connectionState;
 
-        public FireboltClient? Client { get; private set; }
-        public string? EngineUrl { get; private set; }
+        public FireboltClient Client { get; private set; }
+        public string EngineUrl { get; private set; }
 
         /// <summary>
         /// Gets the name of the database specified in the connection settings.
         /// </summary>
         /// <returns>The name of the database specified in the connection settings. The default value is an empty string.</returns>
-        public override string Database => _connectionState.Settings?.Database ?? throw new FireboltException("Database is missing");
+        public override string Database => _connectionState.Settings.Database ?? throw new FireboltException("Database is missing");
 
         public string Password
         {
-            get => _connectionState.Settings?.Password ?? throw new FireboltException("Password parameter is missing in the connection string");
+            get => _connectionState.Settings.Password ?? throw new FireboltException("Password parameter is missing in the connection string");
             set => throw new NotImplementedException();
         }
 
         public string Endpoint
         {
-            get => _connectionState.Settings?.Endpoint ?? Constant.BaseUrl;
+            get => _connectionState.Settings.Endpoint ?? Constant.BaseUrl;
             set => throw new NotImplementedException();
         }
 
         public string Account
         {
-            get => _connectionState.Settings?.Account ?? string.Empty;
+            get => _connectionState.Settings.Account ?? string.Empty;
             set => throw new NotImplementedException();
         }
 

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -214,7 +214,7 @@ namespace FireboltDotNetSdk.Client
         public void SetDefaultEngine()
         {
             CheckClient();
-            EngineUrl = GetDefaultEngineUrl(Client);
+            EngineUrl = GetDefaultEngineUrl(Client!);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace FireboltDotNetSdk.Client
         public void SetEngine(string engineName)
         {
             CheckClient();
-            EngineUrl = GetEngineUrlByEngineName(engineName, Client);
+            EngineUrl = GetEngineUrlByEngineName(engineName, Client!);
         }
 
         private void CheckClient()

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -210,7 +210,7 @@ namespace FireboltDotNetSdk.Client
         /// <summary>
         /// Set engineUrl to use the default engine of the database
         /// </summary>
-        [Obsolete("The default engine is used when the engine is not specified as part of the connection string")]
+        [Obsolete("The default engine is used when the engine is not specified as part of the connection string", false)]
         public void SetDefaultEngine()
         {
             CheckClient();
@@ -221,7 +221,7 @@ namespace FireboltDotNetSdk.Client
         /// Set engineUrl to use the url of the engine provided
         /// </summary>
         /// <param name="engineName">The engine name.</param>
-        [Obsolete("Pass engine as part of the connection string instead")]
+        [Obsolete("Pass engine as part of the connection string instead", false)]
         public void SetEngine(string engineName)
         {
             CheckClient();

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -66,7 +66,7 @@ namespace FireboltDotNetSdk.Client
 
         private string? EngineName
         {
-            get => _connectionState.Settings?.EngineName;
+            get => _connectionState.Settings?.Engine;
         }
 
 
@@ -160,14 +160,7 @@ namespace FireboltDotNetSdk.Client
         {
             Client = new FireboltClient(UserName, Password, Endpoint);
             await Client.EstablishConnection();
-            if (_connectionState.Settings?.EngineUrl != null)
-            {
-                EngineUrl = _connectionState.Settings?.EngineUrl;
-            }
-            else
-            {
-                EngineUrl = EngineName != null ? GetEngineUrlByEngineName(EngineName, Client) : GetDefaultEngineUrl(Client);
-            }
+            EngineUrl = EngineName != null ? GetEngineUrlByEngineName(EngineName, Client) : GetDefaultEngineUrl(Client);
             OnSessionEstablished();
             return EngineUrl != null;
         }
@@ -213,6 +206,28 @@ namespace FireboltDotNetSdk.Client
                     $"Cannot get engine url for {engineName} engine from {_connectionState.Settings?.Database} database", ex);
             }
         }
+
+        [Obsolete("The default engine is used when the engine is not specified as part of the connection string")]
+        public void SetDefaultEngine()
+        {
+            CheckClient();
+            EngineUrl = GetDefaultEngineUrl(Client);
+        }
+
+        [Obsolete("Pass engine as part of the connection string instead")]
+        public void SetEngine(string engineName)
+        {
+            CheckClient();
+            EngineUrl = GetEngineUrlByEngineName(engineName, Client);
+        }
+
+        private void CheckClient()
+        {
+            if (Client is null)
+                throw new NullReferenceException(
+                    "Client is not initialised to perform the operation. Make sure the connection is open.");
+        }
+
 
         /// <summary>
         /// Creates and returns a <see cref="FireboltCommand"/> object associated with the connection.

--- a/FireboltNETSDK/Client/FireboltConnectionSettings.cs
+++ b/FireboltNETSDK/Client/FireboltConnectionSettings.cs
@@ -50,12 +50,7 @@ namespace FireboltDotNetSdk.Client
         /// <summary>
         /// Get the name of the engine
         /// </summary>
-        public string? EngineName { get; }
-
-        /// <summary>
-        /// Get the url of the engine
-        /// </summary>
-        public string? EngineUrl { get; }
+        public string? Engine { get; }
 
         internal FireboltConnectionSettings(FireboltConnectionStringBuilder builder)
         {
@@ -67,8 +62,7 @@ namespace FireboltDotNetSdk.Client
             Database = string.IsNullOrEmpty(builder.Database) ? null : builder.Database;
             Endpoint = string.IsNullOrEmpty(builder.Endpoint) ? null : builder.Endpoint;
             Account = string.IsNullOrEmpty(builder.Account) ? null : builder.Account;
-            EngineName = string.IsNullOrEmpty(builder.EngineName) ? null : builder.EngineName;
-            EngineUrl = string.IsNullOrEmpty(builder.EngineUrl) ? null : builder.EngineUrl;
+            Engine = string.IsNullOrEmpty(builder.Engine) ? null : builder.Engine;
         }
     }
 }

--- a/FireboltNETSDK/Client/FireboltConnectionSettings.cs
+++ b/FireboltNETSDK/Client/FireboltConnectionSettings.cs
@@ -51,7 +51,7 @@ namespace FireboltDotNetSdk.Client
         /// Get the name of the engine
         /// </summary>
         public string? EngineName { get; }
-        
+
         /// <summary>
         /// Get the url of the engine
         /// </summary>

--- a/FireboltNETSDK/Client/FireboltConnectionSettings.cs
+++ b/FireboltNETSDK/Client/FireboltConnectionSettings.cs
@@ -47,6 +47,15 @@ namespace FireboltDotNetSdk.Client
         /// </summary>
         public string? Account { get; }
 
+        /// <summary>
+        /// Get the name of the engine
+        /// </summary>
+        public string? EngineName { get; }
+        
+        /// <summary>
+        /// Get the url of the engine
+        /// </summary>
+        public string? EngineUrl { get; }
 
         internal FireboltConnectionSettings(FireboltConnectionStringBuilder builder)
         {
@@ -58,6 +67,8 @@ namespace FireboltDotNetSdk.Client
             Database = string.IsNullOrEmpty(builder.Database) ? null : builder.Database;
             Endpoint = string.IsNullOrEmpty(builder.Endpoint) ? null : builder.Endpoint;
             Account = string.IsNullOrEmpty(builder.Account) ? null : builder.Account;
+            EngineName = string.IsNullOrEmpty(builder.EngineName) ? null : builder.EngineName;
+            EngineUrl = string.IsNullOrEmpty(builder.EngineUrl) ? null : builder.EngineUrl;
         }
     }
 }

--- a/FireboltNETSDK/Client/FireboltConnectionStringBuilder.cs
+++ b/FireboltNETSDK/Client/FireboltConnectionStringBuilder.cs
@@ -93,7 +93,7 @@ namespace FireboltDotNetSdk.Client
             get => GetString(EngineNameKey);
             init => this[EngineNameKey] = value;
         }
-        
+
         /// <summary>
         /// Get the name of the engine.
         /// </summary>

--- a/FireboltNETSDK/Client/FireboltConnectionStringBuilder.cs
+++ b/FireboltNETSDK/Client/FireboltConnectionStringBuilder.cs
@@ -28,8 +28,6 @@ namespace FireboltDotNetSdk.Client
     public class FireboltConnectionStringBuilder : DbConnectionStringBuilder
     {
         private static readonly HashSet<string> AllProperties;
-        private static readonly string EngineNameKey = "engine_name";
-        private static readonly string EngineUrlKey = "engine_url";
 
         /// <summary>
         /// Gets or sets the name of the user.
@@ -88,19 +86,10 @@ namespace FireboltDotNetSdk.Client
         /// <summary>
         /// Get the name of the engine.
         /// </summary>
-        public string? EngineName
+        public string? Engine
         {
-            get => GetString(EngineNameKey);
-            init => this[EngineNameKey] = value;
-        }
-
-        /// <summary>
-        /// Get the name of the engine.
-        /// </summary>
-        public string? EngineUrl
-        {
-            get => GetString(EngineUrlKey);
-            init => this[EngineUrlKey] = value;
+            get => GetString(nameof(Engine));
+            init => this[nameof(Engine)] = value;
         }
 
         static FireboltConnectionStringBuilder()
@@ -112,8 +101,7 @@ namespace FireboltDotNetSdk.Client
                 nameof(UserName),
                 nameof(Endpoint),
                 nameof(Account),
-                EngineNameKey,
-                EngineUrlKey,
+                nameof(Engine),
             };
         }
 

--- a/FireboltNETSDK/Client/FireboltConnectionStringBuilder.cs
+++ b/FireboltNETSDK/Client/FireboltConnectionStringBuilder.cs
@@ -28,6 +28,8 @@ namespace FireboltDotNetSdk.Client
     public class FireboltConnectionStringBuilder : DbConnectionStringBuilder
     {
         private static readonly HashSet<string> AllProperties;
+        private static readonly string EngineNameKey = "engine_name";
+        private static readonly string EngineUrlKey = "engine_url";
 
         /// <summary>
         /// Gets or sets the name of the user.
@@ -83,6 +85,24 @@ namespace FireboltDotNetSdk.Client
             init => this[nameof(Account)] = value;
         }
 
+        /// <summary>
+        /// Get the name of the engine.
+        /// </summary>
+        public string? EngineName
+        {
+            get => GetString(EngineNameKey);
+            init => this[EngineNameKey] = value;
+        }
+        
+        /// <summary>
+        /// Get the name of the engine.
+        /// </summary>
+        public string? EngineUrl
+        {
+            get => GetString(EngineUrlKey);
+            init => this[EngineUrlKey] = value;
+        }
+
         static FireboltConnectionStringBuilder()
         {
             AllProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -91,7 +111,9 @@ namespace FireboltDotNetSdk.Client
                 nameof(Password),
                 nameof(UserName),
                 nameof(Endpoint),
-                nameof(Account)
+                nameof(Account),
+                EngineNameKey,
+                EngineUrlKey,
             };
         }
 

--- a/FireboltNETSDK/FireboltClient.cs
+++ b/FireboltNETSDK/FireboltClient.cs
@@ -91,14 +91,14 @@ public class FireboltClient
     }
 
     /// <summary>
-    ///     Returns engine URL by engine name given.
+    ///     Returns engine id by engine name.
     /// </summary>
     /// <param name="engine">Name of the engine.</param>
     /// <param name="account">Name of the account</param>
     /// <returns>A successful response.</returns>
-    public Task<GetEngineNameByEngineIdResponse> GetEngineUrlByEngineName(string engine, string? account)
+    public Task<GetEngineIdByEngineNameResponse> GetEngineIdByEngineName(string engine, string? account)
     {
-        return CoreV1GetEngineUrlByEngineNameAsync(engine, account, CancellationToken.None);
+        return CoreV1GetEngineByEngineNameAsync(engine, account, CancellationToken.None);
     }
 
     /// <summary>
@@ -279,7 +279,7 @@ public class FireboltClient
         return await SendAsync<GetEngineUrlByDatabaseNameResponse>(HttpMethod.Get, urlBuilder.ToString(), (string?)null, true, cancellationToken);
     }
 
-    private async Task<GetEngineNameByEngineIdResponse> CoreV1GetEngineUrlByEngineNameAsync(string engine,
+    private async Task<GetEngineIdByEngineNameResponse> CoreV1GetEngineByEngineNameAsync(string engine,
         string? account, CancellationToken cancellationToken)
     {
         if (engine == null) throw new FireboltException("Engine name is incorrect or missing");
@@ -294,7 +294,7 @@ public class FireboltClient
                 engine,
                 CultureInfo.InvariantCulture)));
 
-        return await SendAsync<GetEngineNameByEngineIdResponse>(HttpMethod.Get, urlBuilder.ToString(), (string?)null, true, cancellationToken);
+        return await SendAsync<GetEngineIdByEngineNameResponse>(HttpMethod.Get, urlBuilder.ToString(), (string?)null, true, cancellationToken);
     }
 
     private async Task<T> SendAsync<T>(HttpMethod method, string uri, string? body, bool requiresAuth,

--- a/FireboltNETSDK/FireboltDotNetSdk.csproj
+++ b/FireboltNETSDK/FireboltDotNetSdk.csproj
@@ -24,6 +24,7 @@
     <Authors>Firebolt</Authors>
     <Company>Firebolt</Company>
     <PackageProjectUrl>https://www.firebolt.io/</PackageProjectUrl>
+    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FireboltNETSDK/FireboltDotNetSdk.csproj
+++ b/FireboltNETSDK/FireboltDotNetSdk.csproj
@@ -24,6 +24,7 @@
     <Authors>Firebolt</Authors>
     <Company>Firebolt</Company>
     <PackageProjectUrl>https://www.firebolt.io/</PackageProjectUrl>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FireboltNETSDK/FireboltDotNetSdk.csproj
+++ b/FireboltNETSDK/FireboltDotNetSdk.csproj
@@ -25,6 +25,7 @@
     <Company>Firebolt</Company>
     <PackageProjectUrl>https://www.firebolt.io/</PackageProjectUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FireboltNETSDK/FireboltDotNetSdk.csproj
+++ b/FireboltNETSDK/FireboltDotNetSdk.csproj
@@ -24,7 +24,6 @@
     <Authors>Firebolt</Authors>
     <Company>Firebolt</Company>
     <PackageProjectUrl>https://www.firebolt.io/</PackageProjectUrl>
-    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The goal of this PR is to:

- Enable the passing of engine name as part of the connection string
- Deprecate the method setEngine() and setDefaultEngine()
- Improve exception handling when an engine is not found (fail fast vs setting the url to null and have the connector failing when sending a query to the server).