### PR TITLE
fix: Fix sdk version to conform to a standard

### DIFF
--- a/FireboltNETSDK/FireboltDotNetSdk.csproj
+++ b/FireboltNETSDK/FireboltDotNetSdk.csproj
@@ -6,9 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <FileVersion>1.0.0-alpha</FileVersion>
-    <AssemblyVersion>1.0.0-alpha</AssemblyVersion>
-    <Version>1.0.0-alpha</Version>
+    <FileVersion>1.0.0</FileVersion>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <Version>1.0.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>Utils/images/firebolt_logo.png</PackageIcon>
     <RepositoryUrl>https://github.com/firebolt-db/firebolt-net-sdk</RepositoryUrl>

--- a/FireboltNETSDK/FireboltDotNetSdk.csproj
+++ b/FireboltNETSDK/FireboltDotNetSdk.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <FileVersion>1.0.0</FileVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
-    <Version>1.0.0</Version>
+    <Version>1.0.0-alpha</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>Utils/images/firebolt_logo.png</PackageIcon>
     <RepositoryUrl>https://github.com/firebolt-db/firebolt-net-sdk</RepositoryUrl>


### PR DESCRIPTION
Since a new `1.0.0-alpha` version was created, Github actions bot has automatically updated the version package to `1.0.0-alpha`. But this version value is considered invalid by dotnet, which causes the build to fail. Setting the version to `1.0.0` to fix the build