### PR TITLE
test: FIR-21498 select/insert and prepared statement integration test…

### DIFF
--- a/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
@@ -262,7 +262,7 @@ namespace FireboltDotNetSdk.Tests
             var responseWithPgDate =
                 "{\"query\":{\"query_id\": \"1739956EA85D7647\"},\"meta\":[{\"name\": \"CAST('2022-05-10' AS pgdate)\",\"type\": \"PGDate\"}],\"data\":[[\"2022-05-10\"]],\"rows\": 1,\"statistics\":{\"elapsed\": 0.001887076,\"rows_read\": 1,\"bytes_read\": 1,\"time_before_execution\": 0.000528582,\"time_to_execute\": 0.000203717,\"scanned_bytes_cache\": 0,\"scanned_bytes_storage\": 0}}";
             NewMeta newMeta = ResponseUtilities.getFirstRow(responseWithPgDate);
-            DateOnly expectedDate = DateOnly.FromDateTime(new DateTime(2022, 5, 10, 23, 1, 2, 0));
+            DateTime expectedDate = new DateTime(2022, 5, 10, 0, 0, 0, 0);
             Assert.That(newMeta.Data[0], Is.EqualTo(expectedDate));
             Assert.That(newMeta.Meta, Is.EqualTo("Date"));
         }
@@ -431,7 +431,7 @@ namespace FireboltDotNetSdk.Tests
         public void Prepare()
         {
             DbCommand command = new FireboltCommand();
-            Assert.Throws<NotImplementedException>(() => command.Prepare());
+            Assert.DoesNotThrow(() => command.Prepare()); // just should pass
         }
 
         private DbCommand createCommand(string? query, string? response)

--- a/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
@@ -344,9 +344,19 @@ namespace FireboltDotNetSdk.Tests
                 Rows = 1,
                 Meta = new List<Meta>()
                 {
-                    new Meta() { Name = "guid", Type = "text" },
-                    new Meta() { Name = "text", Type = "text" },
-                    new Meta() { Name = "i", Type = "int" },
+                    new Meta() { Name = "guid", Type = "text" },            // 0
+                    new Meta() { Name = "text", Type = "text" },            // 1
+                    new Meta() { Name = "i", Type = "int" },                // 2
+                    new Meta() { Name = "n", Type = "numeric" },            // 3
+                    new Meta() { Name = "n52", Type = "numeric(5,2)" },     // 4
+                    new Meta() { Name = "dec", Type = "decimal(5,2)" },     // 5
+                    new Meta() { Name = "bi", Type = "bigint" },            // 6
+                    new Meta() { Name = "r", Type = "real" },               // 7
+                    new Meta() { Name = "dp", Type = "DOUBLE PRECISION" },  // 8
+                    new Meta() { Name = "d", Type = "DATE" },               // 9
+                    new Meta() { Name = "ts", Type = "TIMESTAMP" },         //10
+                    new Meta() { Name = "tstz", Type = "TIMESTAMPTZ" },     //11
+                    new Meta() { Name = "b", Type = "boolean" },            //12
                 },
                 Data = new List<List<object?>>()
             };
@@ -359,6 +369,23 @@ namespace FireboltDotNetSdk.Tests
             Assert.That(reader.GetOrdinal("guid"), Is.EqualTo(0));
             Assert.That(reader.GetOrdinal("text"), Is.EqualTo(1));
             Assert.That(reader.GetOrdinal("i"), Is.EqualTo(2));
+
+            Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(string)));
+            Assert.That(reader.GetFieldType(1), Is.EqualTo(typeof(string)));
+            Assert.That(reader.GetFieldType(2), Is.EqualTo(typeof(int)));
+
+            Assert.That(reader.GetFieldType(3), Is.EqualTo(typeof(decimal)));
+            Assert.That(reader.GetFieldType(4), Is.EqualTo(typeof(decimal)));
+            Assert.That(reader.GetFieldType(5), Is.EqualTo(typeof(decimal)));
+            Assert.That(reader.GetFieldType(6), Is.EqualTo(typeof(long)));
+            Assert.That(reader.GetFieldType(7), Is.EqualTo(typeof(float)));
+            Assert.That(reader.GetFieldType(8), Is.EqualTo(typeof(double)));
+
+            Assert.That(reader.GetFieldType(9), Is.EqualTo(typeof(DateTime)));
+            Assert.That(reader.GetFieldType(10), Is.EqualTo(typeof(DateTime)));
+            Assert.That(reader.GetFieldType(11), Is.EqualTo(typeof(DateTime)));
+
+            Assert.That(reader.GetFieldType(12), Is.EqualTo(typeof(bool)));
         }
 
         [Test]

--- a/FireboltDotNetSdk.Tests/Unit/TypesConverterTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/TypesConverterTest.cs
@@ -87,6 +87,9 @@ public class TypesConverterTest
     [TestCase("timestamp")]
     [TestCase("timestamp_ext")]
     [TestCase("datetime")]
+    [TestCase("date")]
+    [TestCase("date_ext")]
+    [TestCase("pgDate")]
     public void ConvertTimestamp(string type)
     {
         ColumnType columnType = ColumnType.Of(type);
@@ -94,18 +97,6 @@ public class TypesConverterTest
         DateTime expectedValue = new DateTime(2022, 5, 10, 23, 1, 2, 0);
         object? result = TypesConverter.ConvertToCSharpVal(value, columnType);
         Assert.That(result, Is.EqualTo(expectedValue));
-    }
-
-    [TestCase("date")]
-    [TestCase("date_ext")]
-    [TestCase("pgDate")]
-    public void ConvertPgDate(string type)
-    {
-        ColumnType columnType = ColumnType.Of(type);
-        var value = "2022-05-10";
-        object? result = TypesConverter.ConvertToCSharpVal(value, columnType);
-        DateOnly expectedDate = DateOnly.FromDateTime(new DateTime(2022, 5, 10, 23, 1, 2, 0));
-        Assert.That(result, Is.EqualTo(expectedDate));
     }
 
     [TestCase("date")]
@@ -150,7 +141,7 @@ public class TypesConverterTest
         object?[] expected =
         {
             1, -1, 257, -257, 80000, -80000, 30000000000, -30000000000, 1.23f, 1.23456789012, "text",
-            DateOnly.Parse("2021-03-28"), new [] { 1, 2, 3, 4 }, 1231232.123459999990457054844258706536, null
+            DateTime.Parse("2021-03-28"), new [] { 1, 2, 3, 4 }, 1231232.123459999990457054844258706536, null
         };
 
         for (int i = 0; i < expected.Length; i++)

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -327,7 +327,7 @@ namespace FireboltDotNetSdk.Client
 
         public override void Prepare()
         {
-            throw new NotImplementedException();
+            // Empty implementation. Nothing to do here so far.
         }
 
         public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)

--- a/FireboltNETSDK/Client/FireboltDataReader.cs
+++ b/FireboltNETSDK/Client/FireboltDataReader.cs
@@ -51,9 +51,11 @@ namespace FireboltDotNetSdk.Client
             { "int64", typeof(long) },
 
             { "float", typeof(float) },
+            { "real", typeof(float) },
             { "double", typeof(double) },
             { "double precision", typeof(double) },
             { "decimal", typeof(decimal) },
+            { "numeric", typeof(decimal) },
 
             { "string", typeof(string) },
             { "text", typeof(string) },
@@ -237,6 +239,7 @@ namespace FireboltDotNetSdk.Client
         private Type? GetTypeByName(string typeName)
         {
             typeName = Regex.Replace(typeName, @"\s+null", "", RegexOptions.IgnoreCase);
+            typeName = Regex.Replace(typeName, @"\(.*", "", RegexOptions.IgnoreCase);
             return typesMap[typeName] ?? typeof(object);
         }
 
@@ -376,7 +379,7 @@ namespace FireboltDotNetSdk.Client
             int n = Math.Min(row.Count, values.Length);
             for (int i = 0; i < n; i++)
             {
-                values[i] = row[i] ?? throw new InvalidOperationException($"Column ${i} is null");
+                values[i] = GetValue(i);
             }
             return n;
         }

--- a/FireboltNETSDK/Utils/Types.cs
+++ b/FireboltNETSDK/Utils/Types.cs
@@ -64,9 +64,8 @@ namespace FireboltDoNetSdk.Utils
                 case FireboltDataType.DateTime:
                 case FireboltDataType.TimestampTz:
                 case FireboltDataType.TimestampNtz:
-                    return ParseDateTime(str);
                 case FireboltDataType.Date:
-                    return DateOnly.FromDateTime(ParseDateTime(str));
+                    return ParseDateTime(str);
                 case FireboltDataType.Short:
                     return Convert.ToInt16(str);
                 case FireboltDataType.Double:


### PR DESCRIPTION
select/insert and prepared statement integration tests + some type fixes.

Standard API does not support `DateOnly`. The DB `date` type is mapped to `DateTime` with the same date and time equal to `00:00:00`.