### PR TITLE
feat: added global.json generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,14 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Set up .NET 6.0
+      id: dotnet-setup
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0
+
+    - name: use .NET 6.0
+      run: |
+        dotnet new globaljson --sdk-version '${{ steps.dotnet-setup.outputs.dotnet-version }}'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,9 +17,14 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Set up .NET 6.0
+      id: dotnet-setup
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0
+
+    - name: use .NET 6.0
+      run: |
+        dotnet new globaljson --sdk-version '${{ steps.dotnet-setup.outputs.dotnet-version }}'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This is simple but very urgent PR that fixes CI/CD problem introduced by github a couple of weeks ago when they updated default version of .NET that caused our build to fail. File `global.json` generated right after .NET SDK installation fixes this problem.