### PR TITLE
ci: Fix release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,12 @@ jobs:
           git commit -m "Automatic version bump to ${{ steps.tag_generation.outputs.new_version }}"
           git push origin main
         shell: bash
+        
+      - name: Publish tag on github
+        run: |
+          git tag ${{ steps.tag_generation.outputs.new_version }}
+          git push origin ${{ steps.tag_generation.outputs.new_version }}
+        shell: bash
 
       - name: Set up .NET 6.0
         id: dotnet-setup
@@ -91,10 +97,4 @@ jobs:
           dotnet nuget push FireboltNETSDK/bin/Debug/FireboltNetSDK.${{ steps.tag_generation.outputs.new_version }}.nupkg \
             --api-key ${{ secrets.PUBLISH_API_KEY }} \
             --source https://api.nuget.org/v3/index.json
-        shell: bash
-        
-      - name: Publish tag on github
-        run: |
-          git tag ${{ steps.tag_generation.outputs.new_version }}
-          git push origin ${{ steps.tag_generation.outputs.new_version }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,16 +69,15 @@ jobs:
           git push origin main
         shell: bash
 
-      - name: Publish tag on github
-        run: |
-          git tag ${{ steps.tag_generation.outputs.new_version }}
-          git push origin ${{ steps.tag_generation.outputs.new_version }}
-        shell: bash
-
       - name: Set up .NET 6.0
+        id: dotnet-setup
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0
+          
+      - name: use .NET 6.0
+        run: |
+          dotnet new globaljson --sdk-version '${{ steps.dotnet-setup.outputs.dotnet-version }}'
 
       - name: Build package
         run: |
@@ -92,4 +91,10 @@ jobs:
           dotnet nuget push FireboltNETSDK/bin/Debug/FireboltNetSDK.${{ steps.tag_generation.outputs.new_version }}.nupkg \
             --api-key ${{ secrets.PUBLISH_API_KEY }} \
             --source https://api.nuget.org/v3/index.json
+        shell: bash
+        
+      - name: Publish tag on github
+        run: |
+          git tag ${{ steps.tag_generation.outputs.new_version }}
+          git push origin ${{ steps.tag_generation.outputs.new_version }}
         shell: bash


### PR DESCRIPTION
A couple of improvements to release action
- Attemt to fix the build by synchronizing build step with how it's done in other actions
- Moved tag pushing to the end of the action