### PR TITLE
fix: Less restrictive next result

### DIFF
--- a/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
@@ -122,11 +122,11 @@ namespace FireboltDotNetSdk.Tests
         public void MultipleResults()
         {
             DbDataReader reader = new FireboltDataReader(null, new QueryResult());
-            Assert.Throws<FireboltException>(() => reader.NextResult());
-            Assert.ThrowsAsync<FireboltException>(() => reader.NextResultAsync());
-            Assert.ThrowsAsync<FireboltException>(() => reader.NextResultAsync(CancellationToken.None));
+            Assert.That(reader.NextResult(), Is.EqualTo(false));
+            Assert.That(reader.NextResultAsync().GetAwaiter().GetResult(), Is.EqualTo(false));
+            Assert.That(reader.NextResultAsync(CancellationToken.None).GetAwaiter().GetResult(), Is.EqualTo(false));
+            Assert.That(reader.NextResultAsync(new CancellationToken(false)).GetAwaiter().GetResult(), Is.EqualTo(false));
             Assert.NotNull(reader.NextResultAsync(new CancellationToken(true)));
-            Assert.ThrowsAsync<FireboltException>(() => reader.NextResultAsync(new CancellationToken(false)));
         }
 
         [Test]

--- a/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
@@ -635,5 +635,34 @@ namespace FireboltDotNetSdk.Tests
             Assert.That(reader.Read(), Is.EqualTo(false));
         }
 
+        [Test]
+        public void DataTableCompatibility()
+        {
+            QueryResult result = new QueryResult
+            {
+                Rows = 1,
+                Meta = new List<Meta>()
+                {
+                    new Meta() { Name = "guid", Type = "text" },
+                    new Meta() { Name = "text", Type = "text" },
+                    new Meta() { Name = "i", Type = "int" },
+                },
+                Data = new List<List<object?>>()
+                {
+                    new List<object?>() { "6B29FC40-CA47-1067-B31D-00DD010662DA", "not guid", 123 }
+                }
+            };
+
+            DbDataReader reader = new FireboltDataReader(null, result);
+
+            DataTable dataTable = new DataTable();
+            dataTable.Load(reader);
+
+            Assert.That(dataTable.Rows.Count, Is.EqualTo(1));
+            Assert.That(dataTable.Rows[0]["guid"], Is.EqualTo("6B29FC40-CA47-1067-B31D-00DD010662DA"));
+            Assert.That(dataTable.Rows[0]["text"], Is.EqualTo("not guid"));
+            Assert.That(dataTable.Rows[0]["i"], Is.EqualTo(123));
+        }
+
     }
 }

--- a/FireboltNETSDK/Client/FireboltDataReader.cs
+++ b/FireboltNETSDK/Client/FireboltDataReader.cs
@@ -500,7 +500,7 @@ namespace FireboltDotNetSdk.Client
         /// <exception cref="FireboltException"></exception>
         public override bool NextResult()
         {
-            throw new FireboltException("Batch operations are not supported");
+            return false;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Remove not implemented error from DataReader.NextResult. Even though we don't support multistatements, we can still just return false all the time and become less restrictive on the apps that require this method. This also unblocks us from building native .net DataTable objects from the reader. Added a test for this compatibility