### PR TITLE
feat(FIR-33629): Supporting structured errors

### DIFF
--- a/FireboltDotNetSdk.Tests/Integration/ConnectionTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ConnectionTest.cs
@@ -54,7 +54,7 @@ namespace FireboltDotNetSdk.Tests
             DbConnection connection = new FireboltConnection(connString);
             Assert.That(connection.ConnectionString, Is.EqualTo(connString));
 
-            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() =>
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () =>
             {
                 connection.Open();
                 if (query != null)
@@ -87,7 +87,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var connString = ConnectionString(new Tuple<string, string?>(nameof(Account), "non-existing-account-123"));
             DbConnection connection = new FireboltConnection(connString);
-            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => connection.Open());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => connection.Open());
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Does.Contain(errorMessage));
         }
@@ -100,7 +100,7 @@ namespace FireboltDotNetSdk.Tests
             DbConnection connection = new FireboltConnection(connString);
             Assert.That(connection.ConnectionString, Is.EqualTo(connString));
             connection.Open();
-            Assert.Throws(Is.InstanceOf<FireboltException>(),() => connection.ChangeDatabase("DOES_NOT_EXIST"));
+            Assert.Throws(Is.InstanceOf<FireboltException>(), () => connection.ChangeDatabase("DOES_NOT_EXIST"));
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace FireboltDotNetSdk.Tests
             DbConnection connection = new FireboltConnection(connString);
             Assert.That(connection.ConnectionString, Is.EqualTo(connString));
             connection.ChangeDatabase("DOES_NOT_EXIST"); // does not fail because connection is not open
-            Assert.Throws(Is.InstanceOf<FireboltException>(),() => connection.Open());
+            Assert.Throws(Is.InstanceOf<FireboltException>(), () => connection.Open());
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace FireboltDotNetSdk.Tests
             var connString = ConnectionString(new Tuple<string, string?>(nameof(Database), "DOES_NOT_EXIST"));
             DbConnection connection = new FireboltConnection(connString);
             Assert.That(connection.ConnectionString, Is.EqualTo(connString));
-            Assert.Throws(Is.InstanceOf<FireboltException>(),() => connection.Open());
+            Assert.Throws(Is.InstanceOf<FireboltException>(), () => connection.Open());
             failingSelect(connection);
             connection.ChangeDatabase(Database);
             connection.Open();
@@ -287,7 +287,7 @@ namespace FireboltDotNetSdk.Tests
 
         private void failingSelect(DbConnection connection)
         {
-            Assert.Throws(Is.InstanceOf<FireboltException>(),() =>
+            Assert.Throws(Is.InstanceOf<FireboltException>(), () =>
             {
                 DbCommand command = connection.CreateCommand();
                 command.CommandText = "SELECT 1";

--- a/FireboltDotNetSdk.Tests/Integration/ConnectionTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ConnectionTest.cs
@@ -54,7 +54,7 @@ namespace FireboltDotNetSdk.Tests
             DbConnection connection = new FireboltConnection(connString);
             Assert.That(connection.ConnectionString, Is.EqualTo(connString));
 
-            FireboltException? exception = Assert.Throws<FireboltException>(() =>
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() =>
             {
                 connection.Open();
                 if (query != null)
@@ -87,7 +87,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var connString = ConnectionString(new Tuple<string, string?>(nameof(Account), "non-existing-account-123"));
             DbConnection connection = new FireboltConnection(connString);
-            FireboltException? exception = Assert.Throws<FireboltException>(() => connection.Open());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => connection.Open());
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Does.Contain(errorMessage));
         }
@@ -100,7 +100,7 @@ namespace FireboltDotNetSdk.Tests
             DbConnection connection = new FireboltConnection(connString);
             Assert.That(connection.ConnectionString, Is.EqualTo(connString));
             connection.Open();
-            FireboltException? exception = Assert.Throws<FireboltException>(() => connection.ChangeDatabase("DOES_NOT_EXIST"));
+            Assert.Throws(Is.InstanceOf<FireboltException>(),() => connection.ChangeDatabase("DOES_NOT_EXIST"));
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace FireboltDotNetSdk.Tests
             DbConnection connection = new FireboltConnection(connString);
             Assert.That(connection.ConnectionString, Is.EqualTo(connString));
             connection.ChangeDatabase("DOES_NOT_EXIST"); // does not fail because connection is not open
-            FireboltException? exception = Assert.Throws<FireboltException>(() => connection.Open());
+            Assert.Throws(Is.InstanceOf<FireboltException>(),() => connection.Open());
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace FireboltDotNetSdk.Tests
             var connString = ConnectionString(new Tuple<string, string?>(nameof(Database), "DOES_NOT_EXIST"));
             DbConnection connection = new FireboltConnection(connString);
             Assert.That(connection.ConnectionString, Is.EqualTo(connString));
-            Assert.Throws<FireboltException>(() => connection.Open());
+            Assert.Throws(Is.InstanceOf<FireboltException>(),() => connection.Open());
             failingSelect(connection);
             connection.ChangeDatabase(Database);
             connection.Open();
@@ -287,7 +287,7 @@ namespace FireboltDotNetSdk.Tests
 
         private void failingSelect(DbConnection connection)
         {
-            Assert.Throws<FireboltException>(() =>
+            Assert.Throws(Is.InstanceOf<FireboltException>(),() =>
             {
                 DbCommand command = connection.CreateCommand();
                 command.CommandText = "SELECT 1";

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -185,7 +185,7 @@ namespace FireboltDotNetSdk.Tests
         private void ExecuteTestInvalidCredentials(string connectionString)
         {
             using var conn = new FireboltConnection(connectionString);
-            FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => conn.Open());
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Does.Contain("The operation is unauthorized\nStatus: 401"));
             Assert.That(exception.ToString(), Does.Contain("FireboltDotNetSdk.Exception.FireboltException: The operation is unauthorized\nStatus: 401"));
@@ -308,7 +308,8 @@ namespace FireboltDotNetSdk.Tests
             conn.Open();
             DbCommand command = conn.CreateCommand();
             command.CommandText = "SET foo=bar";
-            FireboltException exception = Assert.Throws<FireboltException>(() => command.ExecuteNonQuery());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => command.ExecuteNonQuery());
+            Assert.NotNull(exception);
             Assert.That(exception.Response?.Trim(), Does.Contain("not allowed"));
             Assert.That(exception.Response?.Trim(), Does.Contain("foo"));
             conn.Close();
@@ -327,7 +328,8 @@ namespace FireboltDotNetSdk.Tests
             Assert.That(conn.SetParamList, Is.EqualTo(expectedParamerters));
 
             command.CommandText = "SET foo=bar";
-            FireboltException exception = Assert.Throws<FireboltException>(() => command.ExecuteNonQuery());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => command.ExecuteNonQuery());
+            Assert.NotNull(exception);
             Assert.That(exception.Response?.Trim(), Does.Contain("not allowed"));
             Assert.That(exception.Response?.Trim(), Does.Contain("foo"));
             Assert.That(conn.SetParamList, Is.EqualTo(expectedParamerters));
@@ -438,7 +440,7 @@ namespace FireboltDotNetSdk.Tests
         private void ExecuteServiceAccountLoginWithInvalidCredentials(string connectionString)
         {
             using var conn = new FireboltConnection(connectionString);
-            FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => conn.Open());
             Assert.NotNull(exception);
             Assert.IsTrue(exception!.Message.Contains("401"), $"Expected Unauthorized (401) error message but was {exception!.Message}");
         }
@@ -448,7 +450,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteServiceAccountLoginWithMissingSecret(string secretField)
         {
             var connString = ConnectionString(new Tuple<string, string?>(nameof(Engine), null), new Tuple<string, string?>(secretField, ""));
-            FireboltException? exception = Assert.Throws<FireboltException>(() => new FireboltConnection(connString));
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => new FireboltConnection(connString));
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Is.EqualTo("Configuration error: either Password or ClientSecret must be provided but not both"));
         }
@@ -504,7 +506,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var connString = $"{SYSTEM_CONNECTION_STRING};engine=InexistantEngine";
             using var conn = new FireboltConnection(connString);
-            FireboltException? exception = Assert.Throws<FireboltException>(() => conn.Open());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => conn.Open());
             Assert.That(exception!.Message,
                 Does.Match(
                     "Engine.+InexistantEngine.+not"
@@ -544,8 +546,8 @@ namespace FireboltDotNetSdk.Tests
                 conn.Open();
                 DbCommand command = conn.CreateCommand();
                 command.CommandText = "wrong query";
-                Assert.Throws<FireboltException>(() => command.ExecuteReader());
-                Assert.Throws<FireboltException>(() => command.ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(),() => command.ExecuteReader());
+                Assert.Throws(Is.InstanceOf<FireboltException>(),() => command.ExecuteNonQuery());
             }
         }
 

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -185,7 +185,7 @@ namespace FireboltDotNetSdk.Tests
         private void ExecuteTestInvalidCredentials(string connectionString)
         {
             using var conn = new FireboltConnection(connectionString);
-            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => conn.Open());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => conn.Open());
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Does.Contain("The operation is unauthorized\nStatus: 401"));
             Assert.That(exception.ToString(), Does.Contain("FireboltDotNetSdk.Exception.FireboltException: The operation is unauthorized\nStatus: 401"));
@@ -328,7 +328,7 @@ namespace FireboltDotNetSdk.Tests
             Assert.That(conn.SetParamList, Is.EqualTo(expectedParamerters));
 
             command.CommandText = "SET foo=bar";
-            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => command.ExecuteNonQuery());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => command.ExecuteNonQuery());
             Assert.NotNull(exception);
             Assert.That(exception.Response?.Trim(), Does.Contain("not allowed"));
             Assert.That(exception.Response?.Trim(), Does.Contain("foo"));
@@ -440,7 +440,7 @@ namespace FireboltDotNetSdk.Tests
         private void ExecuteServiceAccountLoginWithInvalidCredentials(string connectionString)
         {
             using var conn = new FireboltConnection(connectionString);
-            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => conn.Open());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => conn.Open());
             Assert.NotNull(exception);
             Assert.IsTrue(exception!.Message.Contains("401"), $"Expected Unauthorized (401) error message but was {exception!.Message}");
         }
@@ -450,7 +450,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteServiceAccountLoginWithMissingSecret(string secretField)
         {
             var connString = ConnectionString(new Tuple<string, string?>(nameof(Engine), null), new Tuple<string, string?>(secretField, ""));
-            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => new FireboltConnection(connString));
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => new FireboltConnection(connString));
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Is.EqualTo("Configuration error: either Password or ClientSecret must be provided but not both"));
         }
@@ -506,7 +506,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var connString = $"{SYSTEM_CONNECTION_STRING};engine=InexistantEngine";
             using var conn = new FireboltConnection(connString);
-            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => conn.Open());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => conn.Open());
             Assert.That(exception!.Message,
                 Does.Match(
                     "Engine.+InexistantEngine.+not"
@@ -546,8 +546,8 @@ namespace FireboltDotNetSdk.Tests
                 conn.Open();
                 DbCommand command = conn.CreateCommand();
                 command.CommandText = "wrong query";
-                Assert.Throws(Is.InstanceOf<FireboltException>(),() => command.ExecuteReader());
-                Assert.Throws(Is.InstanceOf<FireboltException>(),() => command.ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(), () => command.ExecuteReader());
+                Assert.Throws(Is.InstanceOf<FireboltException>(), () => command.ExecuteNonQuery());
             }
         }
 

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -6,6 +6,7 @@ using FireboltDotNetSdk.Client;
 using FireboltDotNetSdk.Exception;
 using FireboltDoNetSdk.Utils;
 using NodaTime.Extensions;
+using FireboltNETSDK.Exception;
 
 namespace FireboltDotNetSdk.Tests
 {
@@ -746,6 +747,21 @@ namespace FireboltDotNetSdk.Tests
                 "long", new long[] { 1, 2 }, typeof(long[]),
                 "float", new double[][] { new double[] { 2.7, 3.14 } }, typeof(double[][]), // float is alias to double in engine V2
                 "double", new double[][][] { new double[][] { new double[] { 3.1415926 } } }, typeof(double[][][]));
+        }
+
+        [Test]
+        [Category("v2")]
+        [Category("engine-v2")]
+        public void ThrowsStructuredExceptionOnJSONErrorBody()
+        {
+            using var conn = new FireboltConnection(SYSTEM_CONNECTION_STRING);
+            conn.Open();
+            CreateCommand(conn, "SET advanced_mode=1").ExecuteNonQuery();
+            CreateCommand(conn, "SET enable_json_error_output_format=true").ExecuteNonQuery();
+            DbCommand command = conn.CreateCommand();
+            command.CommandText = "SELECT 'blue'::int";
+            FireboltException exception = Assert.Throws<FireboltStructuredException>(() => command.ExecuteReader());
+            Assert.That(exception.Message, Does.Contain("Cannot parse string 'blue' as integer"));
         }
 
         private void CreateDropFillTableWithArrays(string type1, Array? inta1, Type expType1, string type2, Array? inta2, Type expType2, string type3, Array? inta3, Type expType3)

--- a/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
@@ -82,7 +82,7 @@ namespace FireboltDotNetSdk.Tests
             try
             {
                 var command = CreateCommand("CREATE TABLE IF NOT EXISTS dummy(id INT)");
-                string errorMessage = Assert.Throws<FireboltException>(() => { command.ExecuteNonQuery(); })?.Response ?? "";
+                string errorMessage = ((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => { command.ExecuteNonQuery(); }))?.Response ?? "";
                 Assert.That(errorMessage.Trim(), Is.EqualTo($"Database '{Database}' does not exist or not authorized."));
             }
             finally
@@ -104,7 +104,7 @@ namespace FireboltDotNetSdk.Tests
             try
             {
                 var command = CreateCommand("CREATE TABLE IF NOT EXISTS dummy(id INT); SELECT * FROM dummy");
-                string errorMessage = Assert.Throws<FireboltException>(() => { command.ExecuteNonQuery(); })?.Response ?? "";
+                string errorMessage = ((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => { command.ExecuteNonQuery(); }))?.Response ?? "";
                 Assert.True(new Regex("Run this (query|statement) on a user engine.").Match(errorMessage).Success);
             }
             finally
@@ -135,7 +135,7 @@ namespace FireboltDotNetSdk.Tests
         {
             DbCommand command = Connection.CreateCommand();
             command.CommandText = "SHOW DATABASES";
-            Assert.That(Assert.Throws<FireboltException>(() => command.ExecuteReader()).Response!.Trim(), Is.EqualTo("Should not be called on firebolt V1"));
+            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => command.ExecuteReader()))!.Response!.Trim(), Is.EqualTo("Should not be called on firebolt V1"));
         }
 
         private void CheckEngineExistsWithDB(DbCommand command, string engineName, string dbName)
@@ -160,17 +160,17 @@ namespace FireboltDotNetSdk.Tests
             var command = Connection.CreateCommand();
 
             CheckEngineExistsWithDB(command, newEngineName, newDatabaseName);
-            Assert.That(Assert.Throws<FireboltException>(() => ConnectAndRunQuery())?.Message, Is.EqualTo($"Engine {newEngineName} is not running"));
+            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not running"));
 
             CreateCommand($"DETACH ENGINE {newEngineName} FROM {newDatabaseName}").ExecuteNonQuery();
 
             CheckEngineExistsWithDB(command, newEngineName, "-");
-            Assert.That(Assert.Throws<FireboltException>(() => ConnectAndRunQuery())?.Message, Is.EqualTo($"Engine {newEngineName} is not attached to {newDatabaseName}"));
+            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not attached to {newDatabaseName}"));
 
             CreateCommand($"ATTACH ENGINE {newEngineName} TO {newDatabaseName}").ExecuteNonQuery();
 
             CheckEngineExistsWithDB(command, newEngineName, newDatabaseName);
-            Assert.That(Assert.Throws<FireboltException>(() => ConnectAndRunQuery())?.Message, Is.EqualTo($"Engine {newEngineName} is not running"));
+            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not running"));
         }
 
         private void VerifyEngineSpec(DbCommand command, string engineName, string spec)
@@ -259,7 +259,7 @@ namespace FireboltDotNetSdk.Tests
                 Assert.IsNull(GetTableDbName(table1)); // the table does not exist yet
                 CreateCommand($"CREATE TABLE {table1} ( id LONG)").ExecuteNonQuery(); // create table1 in current DB
                 Assert.That(GetTableDbName(table1), Is.EqualTo(Database)); // now table t1 exists
-                Assert.Throws<FireboltException>(() => CreateCommand($"use {entityType} {databaseName}").ExecuteNonQuery()); // DB does not exist
+                Assert.Throws(Is.InstanceOf<FireboltException>(),() => CreateCommand($"use {entityType} {databaseName}").ExecuteNonQuery()); // DB does not exist
                 CreateCommand($"CREATE DATABASE IF NOT EXISTS {databaseName}").ExecuteNonQuery(); // create DB
                 CreateCommand($"use {entityType} {databaseName}").ExecuteNonQuery(); // Now this should succeed            
                 CreateCommand($"CREATE TABLE {table2} ( id LONG)").ExecuteNonQuery(); // create table2 in other DB
@@ -293,7 +293,7 @@ namespace FireboltDotNetSdk.Tests
             try
             {
                 CreateCommand("USE ENGINE SYSTEM").ExecuteNonQuery();
-                Assert.Throws<FireboltException>(() => CreateCommand($"use ENGINE {engineName}").ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(),() => CreateCommand($"use ENGINE {engineName}").ExecuteNonQuery());
                 CreateCommand($"CREATE ENGINE {engineName}").ExecuteNonQuery();
                 CreateCommand($"USE ENGINE {engineName}").ExecuteNonQuery();
                 CreateCommand($"CREATE DATABASE IF NOT EXISTS {databaseName}").ExecuteNonQuery();
@@ -302,7 +302,7 @@ namespace FireboltDotNetSdk.Tests
                 CreateCommand($"INSERT INTO {table1} (id) VALUES (1)").ExecuteNonQuery();// should succeed using user engine
                 // switch back to the system engine
                 CreateCommand("USE ENGINE SYSTEM").ExecuteNonQuery();
-                Assert.Throws<FireboltException>(() => CreateCommand($"INSERT INTO {table1} (id) VALUES (1)").ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(),() => CreateCommand($"INSERT INTO {table1} (id) VALUES (1)").ExecuteNonQuery());
             }
             finally
             {
@@ -327,7 +327,7 @@ namespace FireboltDotNetSdk.Tests
                 CreateCommand("USE ENGINE SYSTEM").ExecuteNonQuery();
                 CreateCommand($"CREATE ENGINE \"{engineName}\"").ExecuteNonQuery();
                 CreateCommand($"USE ENGINE \"{engineName}\"").ExecuteNonQuery();
-                Assert.Throws<FireboltException>(() => CreateCommand($"USE ENGINE {engineName}").ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(), () => CreateCommand($"USE ENGINE {engineName}").ExecuteNonQuery());
             }
             finally
             {
@@ -352,14 +352,14 @@ namespace FireboltDotNetSdk.Tests
                 CreateCommand($"CREATE ENGINE {engineName}").ExecuteNonQuery();
                 CreateCommand($"USE ENGINE {engineName}").ExecuteNonQuery();
                 // engine name remains mixed case and statement fails because engine name was not quoted when we created the engine
-                Assert.Throws<FireboltException>(() => CreateCommand($"USE ENGINE \"{engineName}\"").ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(),() => CreateCommand($"USE ENGINE \"{engineName}\"").ExecuteNonQuery());
             }
             finally
             {
                 executeSafely(
                     $"USE ENGINE SYSTEM",
-                    $"STOP ENGINE {engineName}",
-                    $"DROP ENGINE {engineName}"
+                    $"STOP ENGINE \"{engineName}\"",
+                    $"DROP ENGINE \"{engineName}\""
                 );
             }
         }
@@ -441,7 +441,7 @@ namespace FireboltDotNetSdk.Tests
                 var badConnection = new FireboltConnection(connectionString);
                 badConnection.CleanupCache();
 
-                Assert.That(Assert.Throws<FireboltException>(() => badConnection.Open())?.Message, Does.Match("([Aa]ccount '.+?' does not exist)|(Received an unexpected status code from the server)"));
+                Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => badConnection.Open()))?.Message, Does.Match("([Aa]ccount '.+?' does not exist)|(Received an unexpected status code from the server)"));
             }
             finally
             {

--- a/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
@@ -358,8 +358,8 @@ namespace FireboltDotNetSdk.Tests
             {
                 executeSafely(
                     $"USE ENGINE SYSTEM",
-                    $"STOP ENGINE \"{engineName}\"",
-                    $"DROP ENGINE \"{engineName}\""
+                    $"STOP ENGINE {engineName}",
+                    $"DROP ENGINE {engineName}"
                 );
             }
         }

--- a/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
@@ -82,7 +82,7 @@ namespace FireboltDotNetSdk.Tests
             try
             {
                 var command = CreateCommand("CREATE TABLE IF NOT EXISTS dummy(id INT)");
-                string errorMessage = ((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => { command.ExecuteNonQuery(); }))?.Response ?? "";
+                string errorMessage = ((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => { command.ExecuteNonQuery(); }))?.Response ?? "";
                 Assert.That(errorMessage.Trim(), Is.EqualTo($"Database '{Database}' does not exist or not authorized."));
             }
             finally
@@ -135,7 +135,7 @@ namespace FireboltDotNetSdk.Tests
         {
             DbCommand command = Connection.CreateCommand();
             command.CommandText = "SHOW DATABASES";
-            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => command.ExecuteReader()))!.Response!.Trim(), Is.EqualTo("Should not be called on firebolt V1"));
+            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => command.ExecuteReader()))!.Response!.Trim(), Is.EqualTo("Should not be called on firebolt V1"));
         }
 
         private void CheckEngineExistsWithDB(DbCommand command, string engineName, string dbName)
@@ -160,17 +160,17 @@ namespace FireboltDotNetSdk.Tests
             var command = Connection.CreateCommand();
 
             CheckEngineExistsWithDB(command, newEngineName, newDatabaseName);
-            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not running"));
+            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not running"));
 
             CreateCommand($"DETACH ENGINE {newEngineName} FROM {newDatabaseName}").ExecuteNonQuery();
 
             CheckEngineExistsWithDB(command, newEngineName, "-");
-            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not attached to {newDatabaseName}"));
+            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not attached to {newDatabaseName}"));
 
             CreateCommand($"ATTACH ENGINE {newEngineName} TO {newDatabaseName}").ExecuteNonQuery();
 
             CheckEngineExistsWithDB(command, newEngineName, newDatabaseName);
-            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not running"));
+            Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => ConnectAndRunQuery()))?.Message, Is.EqualTo($"Engine {newEngineName} is not running"));
         }
 
         private void VerifyEngineSpec(DbCommand command, string engineName, string spec)
@@ -259,7 +259,7 @@ namespace FireboltDotNetSdk.Tests
                 Assert.IsNull(GetTableDbName(table1)); // the table does not exist yet
                 CreateCommand($"CREATE TABLE {table1} ( id LONG)").ExecuteNonQuery(); // create table1 in current DB
                 Assert.That(GetTableDbName(table1), Is.EqualTo(Database)); // now table t1 exists
-                Assert.Throws(Is.InstanceOf<FireboltException>(),() => CreateCommand($"use {entityType} {databaseName}").ExecuteNonQuery()); // DB does not exist
+                Assert.Throws(Is.InstanceOf<FireboltException>(), () => CreateCommand($"use {entityType} {databaseName}").ExecuteNonQuery()); // DB does not exist
                 CreateCommand($"CREATE DATABASE IF NOT EXISTS {databaseName}").ExecuteNonQuery(); // create DB
                 CreateCommand($"use {entityType} {databaseName}").ExecuteNonQuery(); // Now this should succeed            
                 CreateCommand($"CREATE TABLE {table2} ( id LONG)").ExecuteNonQuery(); // create table2 in other DB
@@ -293,7 +293,7 @@ namespace FireboltDotNetSdk.Tests
             try
             {
                 CreateCommand("USE ENGINE SYSTEM").ExecuteNonQuery();
-                Assert.Throws(Is.InstanceOf<FireboltException>(),() => CreateCommand($"use ENGINE {engineName}").ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(), () => CreateCommand($"use ENGINE {engineName}").ExecuteNonQuery());
                 CreateCommand($"CREATE ENGINE {engineName}").ExecuteNonQuery();
                 CreateCommand($"USE ENGINE {engineName}").ExecuteNonQuery();
                 CreateCommand($"CREATE DATABASE IF NOT EXISTS {databaseName}").ExecuteNonQuery();
@@ -302,7 +302,7 @@ namespace FireboltDotNetSdk.Tests
                 CreateCommand($"INSERT INTO {table1} (id) VALUES (1)").ExecuteNonQuery();// should succeed using user engine
                 // switch back to the system engine
                 CreateCommand("USE ENGINE SYSTEM").ExecuteNonQuery();
-                Assert.Throws(Is.InstanceOf<FireboltException>(),() => CreateCommand($"INSERT INTO {table1} (id) VALUES (1)").ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(), () => CreateCommand($"INSERT INTO {table1} (id) VALUES (1)").ExecuteNonQuery());
             }
             finally
             {
@@ -352,7 +352,7 @@ namespace FireboltDotNetSdk.Tests
                 CreateCommand($"CREATE ENGINE {engineName}").ExecuteNonQuery();
                 CreateCommand($"USE ENGINE {engineName}").ExecuteNonQuery();
                 // engine name remains mixed case and statement fails because engine name was not quoted when we created the engine
-                Assert.Throws(Is.InstanceOf<FireboltException>(),() => CreateCommand($"USE ENGINE \"{engineName}\"").ExecuteNonQuery());
+                Assert.Throws(Is.InstanceOf<FireboltException>(), () => CreateCommand($"USE ENGINE \"{engineName}\"").ExecuteNonQuery());
             }
             finally
             {
@@ -441,7 +441,7 @@ namespace FireboltDotNetSdk.Tests
                 var badConnection = new FireboltConnection(connectionString);
                 badConnection.CleanupCache();
 
-                Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(),() => badConnection.Open()))?.Message, Does.Match("([Aa]ccount '.+?' does not exist)|(Received an unexpected status code from the server)"));
+                Assert.That(((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => badConnection.Open()))?.Message, Does.Match("([Aa]ccount '.+?' does not exist)|(Received an unexpected status code from the server)"));
             }
             finally
             {

--- a/FireboltDotNetSdk.Tests/Unit/FireboltClientTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltClientTest.cs
@@ -229,10 +229,10 @@ namespace FireboltDotNetSdk.Tests
             var connection = new FireboltConnection("database=testdb.ib;clientid=testuser;clientsecret=test_pwd;account=accountname");
             FireboltClient2 client = new FireboltClient2(connection, Guid.NewGuid().ToString(), "password", "", "test", "account", httpClientMock.Object);
 
-            FireboltException? e = Assert.Throws<FireboltException>(() => client.GetSystemEngineUrl("my_account").GetAwaiter().GetResult());
+            FireboltException? e = (FireboltException?) Assert.Throws(Is.InstanceOf<FireboltException>(),() => client.GetSystemEngineUrl("my_account").GetAwaiter().GetResult());
             Assert.That(e?.Message, Does.StartWith($"Account 'my_account' does not exist"));
 
-            e = Assert.Throws<FireboltException>(() => client.GetAccountIdByNameAsync("your_account", CancellationToken.None).GetAwaiter().GetResult());
+            e = (FireboltException?) Assert.Throws(Is.InstanceOf<FireboltException>(),() => client.GetAccountIdByNameAsync("your_account", CancellationToken.None).GetAwaiter().GetResult());
             Assert.That(e?.Message, Does.StartWith($"Account 'your_account' does not exist"));
         }
 

--- a/FireboltDotNetSdk.Tests/Unit/FireboltClientTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltClientTest.cs
@@ -229,10 +229,10 @@ namespace FireboltDotNetSdk.Tests
             var connection = new FireboltConnection("database=testdb.ib;clientid=testuser;clientsecret=test_pwd;account=accountname");
             FireboltClient2 client = new FireboltClient2(connection, Guid.NewGuid().ToString(), "password", "", "test", "account", httpClientMock.Object);
 
-            FireboltException? e = (FireboltException?) Assert.Throws(Is.InstanceOf<FireboltException>(),() => client.GetSystemEngineUrl("my_account").GetAwaiter().GetResult());
+            FireboltException? e = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => client.GetSystemEngineUrl("my_account").GetAwaiter().GetResult());
             Assert.That(e?.Message, Does.StartWith($"Account 'my_account' does not exist"));
 
-            e = (FireboltException?) Assert.Throws(Is.InstanceOf<FireboltException>(),() => client.GetAccountIdByNameAsync("your_account", CancellationToken.None).GetAwaiter().GetResult());
+            e = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => client.GetAccountIdByNameAsync("your_account", CancellationToken.None).GetAwaiter().GetResult());
             Assert.That(e?.Message, Does.StartWith($"Account 'your_account' does not exist"));
         }
 

--- a/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
@@ -107,7 +107,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectWhenConnectionIsMissingTest(string commandText)
         {
             var cs = new FireboltCommand { CommandText = commandText };
-            FireboltException? exception = (FireboltException?) Assert.Throws(Is.InstanceOf<FireboltException>(),() => cs.ExecuteReader());
+            FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => cs.ExecuteReader());
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Is.EqualTo("Unable to execute SQL as no connection was initialised. Create command using working connection"));
         }
@@ -150,7 +150,7 @@ namespace FireboltDotNetSdk.Tests
         {
             string response = "not a json";
             var cs = createCommand("select 1", response);
-            string? message = ((FireboltException?) Assert.Throws(Is.InstanceOf<FireboltException>(),() => cs.ExecuteReader()))?.Message;
+            string? message = ((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => cs.ExecuteReader()))?.Message;
             Assert.That(message, Does.Contain("Failed to execute a query"));
         }
 

--- a/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
@@ -107,7 +107,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectWhenConnectionIsMissingTest(string commandText)
         {
             var cs = new FireboltCommand { CommandText = commandText };
-            FireboltException? exception = Assert.Throws<FireboltException>(() => cs.ExecuteReader());
+            FireboltException? exception = Assert.Throws(Is.InstanceOf<FireboltException>(),(() => cs.ExecuteReader());
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Is.EqualTo("Unable to execute SQL as no connection was initialised. Create command using working connection"));
         }
@@ -150,7 +150,7 @@ namespace FireboltDotNetSdk.Tests
         {
             string response = "not a json";
             var cs = createCommand("select 1", response);
-            string message = Assert.Throws<FireboltException>(() => cs.ExecuteReader()).Message;
+            string message = Assert.Throws(Is.InstanceOf<FireboltException>(),(() => cs.ExecuteReader()).Message;
             Assert.That(message, Does.Contain("Failed to execute a query"));
         }
 

--- a/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
@@ -24,7 +24,7 @@ namespace FireboltDotNetSdk.Tests
         {
             _response = response;
             _tokenStorage.CacheToken(new LoginResponse("token", "60", "type"), "id", "secret").Wait();
-            EstablishConnection();
+            EstablishConnection().GetAwaiter().GetResult();
         }
 
         override public Task<string?> ExecuteQuery(string? engineEndpoint, string? databaseName, string? accountId, HashSet<string> setParamList, string query)
@@ -107,7 +107,7 @@ namespace FireboltDotNetSdk.Tests
         public void ExecuteSelectWhenConnectionIsMissingTest(string commandText)
         {
             var cs = new FireboltCommand { CommandText = commandText };
-            FireboltException? exception = Assert.Throws(Is.InstanceOf<FireboltException>(),(() => cs.ExecuteReader());
+            FireboltException? exception = (FireboltException?) Assert.Throws(Is.InstanceOf<FireboltException>(),() => cs.ExecuteReader());
             Assert.NotNull(exception);
             Assert.That(exception!.Message, Is.EqualTo("Unable to execute SQL as no connection was initialised. Create command using working connection"));
         }
@@ -150,7 +150,7 @@ namespace FireboltDotNetSdk.Tests
         {
             string response = "not a json";
             var cs = createCommand("select 1", response);
-            string message = Assert.Throws(Is.InstanceOf<FireboltException>(),(() => cs.ExecuteReader()).Message;
+            string? message = ((FireboltException?) Assert.Throws(Is.InstanceOf<FireboltException>(),() => cs.ExecuteReader()))?.Message;
             Assert.That(message, Does.Contain("Failed to execute a query"));
         }
 

--- a/FireboltDotNetSdk.Tests/Unit/FireboltStructuredExceptionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltStructuredExceptionTest.cs
@@ -1,25 +1,18 @@
-using Newtonsoft.Json;
 using FireboltNETSDK.Exception;
+using FireboltDotNetSdk.Utils;
 
 namespace FireboltDotNetSdk.Tests
 {
     [TestFixture]
     public class FireboltStructuredExceptionTests
     {
-        [Test]
-        public void InitializationWithEmptyString_ShouldNotThrow()
-        {
-            Assert.DoesNotThrow(() => new FireboltStructuredException(""));
-        }
 
         [Test]
         public void ParseSingleError_AllFieldsPopulated_ShouldMatchExpectedFormat()
         {
-            string inputJson = JsonConvert.SerializeObject(new ErrorBodies
-            {
-                Errors = new[]
+            var input = new[]
                 {
-                    new StructuredException
+                    new StructuredError
                     {
                         Code = "1001",
                         Name = "TestError",
@@ -30,46 +23,42 @@ namespace FireboltDotNetSdk.Tests
                         HelpLink = "http://help.link",
                         Location = new Location { FailingLine = 42, StartOffset = 5, EndOffset = 10 }
                     }
-                }
-            });
+                };
 
-            var exception = new FireboltStructuredException(inputJson);
+            var exception = new FireboltStructuredException(input.ToList());
             string expected = "ERROR: TestError (1001) - UnitTest, This is a test error., resolution: Resolve it. at FailingLine: 42, StartOffset: 5, EndOffset: 10, see http://help.link\n";
             Assert.That(exception.Message, Is.EqualTo(expected));
         }
         [Test]
         public void ParseMultipleErrors_AllFieldsPopulated_ShouldMatchExpectedFormat()
         {
-            string inputJson = JsonConvert.SerializeObject(new ErrorBodies
-            {
-                Errors = new[]
+            var input = new[]
                 {
-            new StructuredException
-            {
-                Code = "2001",
-                Name = "FirstError",
-                Severity = "WARNING",
-                Source = "UnitTest1",
-                Description = "This is the first test error.",
-                Resolution = "Resolve it first.",
-                HelpLink = "http://help.first.link",
-                Location = new Location { FailingLine = 10, StartOffset = 1, EndOffset = 5 }
-            },
-            new StructuredException
-            {
-                Code = "2002",
-                Name = "SecondError",
-                Severity = "ERROR",
-                Source = "UnitTest2",
-                Description = "This is the second test error.",
-                Resolution = "Resolve it second.",
-                HelpLink = "http://help.second.link",
-                Location = new Location { FailingLine = 20, StartOffset = 2, EndOffset = 6 }
-            }
-        }
-            });
+                    new StructuredError
+                    {
+                        Code = "2001",
+                        Name = "FirstError",
+                        Severity = "WARNING",
+                        Source = "UnitTest1",
+                        Description = "This is the first test error.",
+                        Resolution = "Resolve it first.",
+                        HelpLink = "http://help.first.link",
+                        Location = new Location { FailingLine = 10, StartOffset = 1, EndOffset = 5 }
+                    },
+                    new StructuredError
+                    {
+                        Code = "2002",
+                        Name = "SecondError",
+                        Severity = "ERROR",
+                        Source = "UnitTest2",
+                        Description = "This is the second test error.",
+                        Resolution = "Resolve it second.",
+                        HelpLink = "http://help.second.link",
+                        Location = new Location { FailingLine = 20, StartOffset = 2, EndOffset = 6 }
+                    }
+                };
 
-            var exception = new FireboltStructuredException(inputJson);
+            var exception = new FireboltStructuredException(input.ToList());
             string expected = "WARNING: FirstError (2001) - UnitTest1, This is the first test error., resolution: Resolve it first. at FailingLine: 10, StartOffset: 1, EndOffset: 5, see http://help.first.link\n" +
                               "ERROR: SecondError (2002) - UnitTest2, This is the second test error., resolution: Resolve it second. at FailingLine: 20, StartOffset: 2, EndOffset: 6, see http://help.second.link\n";
             Assert.That(exception.Message, Is.EqualTo(expected));
@@ -78,31 +67,20 @@ namespace FireboltDotNetSdk.Tests
         [Test]
         public void ParseError_MissingFields_ShouldHandleGracefully()
         {
-            string inputJson = JsonConvert.SerializeObject(new ErrorBodies
+            var input = new[]
             {
-                Errors = new[]
+                new StructuredError
                 {
-            new StructuredException
-            {
-                Code = "3001",
-                Name = "MissingFieldsError",
-                Severity = "ERROR",
-                // Missing Source, Description, Resolution, HelpLink, Location
-            }
-        }
-            });
+                    Code = "3001",
+                    Name = "MissingFieldsError",
+                    Severity = "ERROR",
+                    // Missing Source, Description, Resolution, HelpLink, Location
+                }
+            };
 
-            var exception = new FireboltStructuredException(inputJson);
+            var exception = new FireboltStructuredException(input.ToList());
             string expected = "ERROR: MissingFieldsError (3001)\n";
             Assert.That(exception.Message, Is.EqualTo(expected));
-        }
-
-        [Test]
-        public void ParseInvalidJson_ShouldThrowFormatException()
-        {
-            string inputJson = "This is not a valid JSON string.";
-
-            Assert.Throws<JsonReaderException>(() => new FireboltStructuredException(inputJson));
         }
     }
 }

--- a/FireboltDotNetSdk.Tests/Unit/FireboltStructuredExceptionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltStructuredExceptionTest.cs
@@ -82,5 +82,12 @@ namespace FireboltDotNetSdk.Tests
             string expected = "ERROR: MissingFieldsError (3001)\n";
             Assert.That(exception.Message, Is.EqualTo(expected));
         }
+
+        [Test]
+        public void ParseEmptyList_ShouldReturnEmptyString()
+        {
+            var exception = new FireboltStructuredException(new List<StructuredError>());
+            Assert.That(exception.Message, Is.EqualTo(""));
+        }
     }
 }

--- a/FireboltDotNetSdk.Tests/Unit/FireboltStructuredExceptionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltStructuredExceptionTest.cs
@@ -1,0 +1,108 @@
+using Newtonsoft.Json;
+using FireboltNETSDK.Exception;
+
+namespace FireboltDotNetSdk.Tests
+{
+    [TestFixture]
+    public class FireboltStructuredExceptionTests
+    {
+        [Test]
+        public void InitializationWithEmptyString_ShouldNotThrow()
+        {
+            Assert.DoesNotThrow(() => new FireboltStructuredException(""));
+        }
+
+        [Test]
+        public void ParseSingleError_AllFieldsPopulated_ShouldMatchExpectedFormat()
+        {
+            string inputJson = JsonConvert.SerializeObject(new ErrorBodies
+            {
+                Errors = new[]
+                {
+                    new StructuredException
+                    {
+                        Code = "1001",
+                        Name = "TestError",
+                        Severity = "ERROR",
+                        Source = "UnitTest",
+                        Description = "This is a test error.",
+                        Resolution = "Resolve it.",
+                        HelpLink = "http://help.link",
+                        Location = new Location { FailingLine = 42, StartOffset = 5, EndOffset = 10 }
+                    }
+                }
+            });
+
+            var exception = new FireboltStructuredException(inputJson);
+            string expected = "ERROR: TestError (1001) - UnitTest, This is a test error., resolution: Resolve it. at FailingLine: 42, StartOffset: 5, EndOffset: 10, see http://help.link\n";
+            Assert.That(exception.Message, Is.EqualTo(expected));
+        }
+        [Test]
+        public void ParseMultipleErrors_AllFieldsPopulated_ShouldMatchExpectedFormat()
+        {
+            string inputJson = JsonConvert.SerializeObject(new ErrorBodies
+            {
+                Errors = new[]
+                {
+            new StructuredException
+            {
+                Code = "2001",
+                Name = "FirstError",
+                Severity = "WARNING",
+                Source = "UnitTest1",
+                Description = "This is the first test error.",
+                Resolution = "Resolve it first.",
+                HelpLink = "http://help.first.link",
+                Location = new Location { FailingLine = 10, StartOffset = 1, EndOffset = 5 }
+            },
+            new StructuredException
+            {
+                Code = "2002",
+                Name = "SecondError",
+                Severity = "ERROR",
+                Source = "UnitTest2",
+                Description = "This is the second test error.",
+                Resolution = "Resolve it second.",
+                HelpLink = "http://help.second.link",
+                Location = new Location { FailingLine = 20, StartOffset = 2, EndOffset = 6 }
+            }
+        }
+            });
+
+            var exception = new FireboltStructuredException(inputJson);
+            string expected = "WARNING: FirstError (2001) - UnitTest1, This is the first test error., resolution: Resolve it first. at FailingLine: 10, StartOffset: 1, EndOffset: 5, see http://help.first.link\n" +
+                              "ERROR: SecondError (2002) - UnitTest2, This is the second test error., resolution: Resolve it second. at FailingLine: 20, StartOffset: 2, EndOffset: 6, see http://help.second.link\n";
+            Assert.That(exception.Message, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ParseError_MissingFields_ShouldHandleGracefully()
+        {
+            string inputJson = JsonConvert.SerializeObject(new ErrorBodies
+            {
+                Errors = new[]
+                {
+            new StructuredException
+            {
+                Code = "3001",
+                Name = "MissingFieldsError",
+                Severity = "ERROR",
+                // Missing Source, Description, Resolution, HelpLink, Location
+            }
+        }
+            });
+
+            var exception = new FireboltStructuredException(inputJson);
+            string expected = "ERROR: MissingFieldsError (3001)\n";
+            Assert.That(exception.Message, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ParseInvalidJson_ShouldThrowFormatException()
+        {
+            string inputJson = "This is not a valid JSON string.";
+
+            Assert.Throws<JsonReaderException>(() => new FireboltStructuredException(inputJson));
+        }
+    }
+}

--- a/FireboltNETSDK/Exception/FireboltStructuredException.cs
+++ b/FireboltNETSDK/Exception/FireboltStructuredException.cs
@@ -7,11 +7,7 @@ namespace FireboltNETSDK.Exception
     public class FireboltStructuredException : FireboltException
     {
 
-        // public FireboltStructuredException(string message) : base(ParseErrors(message))
-        // {
-        // }
-
-        public FireboltStructuredException(List<StructuredError> errors): base(ParseErrors(errors))
+        public FireboltStructuredException(List<StructuredError> errors) : base(ParseErrors(errors))
         {
         }
 

--- a/FireboltNETSDK/Exception/FireboltStructuredException.cs
+++ b/FireboltNETSDK/Exception/FireboltStructuredException.cs
@@ -1,0 +1,78 @@
+using FireboltDotNetSdk.Exception;
+using FireboltDotNetSdk.Utils;
+using Newtonsoft.Json;
+
+namespace FireboltNETSDK.Exception
+{
+    public class FireboltStructuredException : FireboltException
+    {
+
+        // public FireboltStructuredException(string message) : base(ParseErrors(message))
+        // {
+        // }
+
+        public FireboltStructuredException(List<StructuredError> errors): base(ParseErrors(errors))
+        {
+        }
+
+        private static string ParseErrors(List<StructuredError> errors)
+        {
+            string parsedErrors = "";
+            // "{severity}: {name} ({code}) - {source}, {description}, resolution: {resolution} at {location} see {helpLink}"
+            foreach (var error in errors)
+            {
+                if (!string.IsNullOrEmpty(error.Severity))
+                {
+                    parsedErrors += $"{error.Severity}:";
+                }
+                if (!string.IsNullOrEmpty(error.Name))
+                {
+                    parsedErrors += $" {error.Name}";
+                }
+                if (!string.IsNullOrEmpty(error.Code))
+                {
+                    parsedErrors += $" ({error.Code})";
+                }
+                if (!string.IsNullOrEmpty(error.Source))
+                {
+                    parsedErrors += $" - {error.Source}";
+                }
+                if (!string.IsNullOrEmpty(error.Description))
+                {
+                    parsedErrors += $", {error.Description}";
+                }
+                if (!string.IsNullOrEmpty(error.Resolution))
+                {
+                    parsedErrors += $", resolution: {error.Resolution}";
+                }
+                if (error.Location != null)
+                {
+                    parsedErrors += $" at {GetReadableLocation(error.Location)}";
+                }
+                if (!string.IsNullOrEmpty(error.HelpLink))
+                {
+                    parsedErrors += $", see {error.HelpLink}";
+                }
+                parsedErrors += "\n";
+            }
+            return parsedErrors;
+        }
+        private static string GetReadableLocation(Location location)
+        {
+            string readableLocation = "";
+            if (location.FailingLine != null)
+            {
+                readableLocation += $"FailingLine: {location.FailingLine}";
+            }
+            if (location.StartOffset != null)
+            {
+                readableLocation += $", StartOffset: {location.StartOffset}";
+            }
+            if (location.EndOffset != null)
+            {
+                readableLocation += $", EndOffset: {location.EndOffset}";
+            }
+            return readableLocation;
+        }
+    }
+}

--- a/FireboltNETSDK/FireboltClient.cs
+++ b/FireboltNETSDK/FireboltClient.cs
@@ -259,7 +259,7 @@ public abstract class FireboltClient
                 headers[item.Key] = item.Value;
 
             try {
-                var anyResponse = await ReadObjectResponseAsync<QueryResult>(response, headers, readResponseAsString: true, cancellationToken).ConfigureAwait(false);
+                var anyResponse = await ReadObjectResponseAsync<JsonErrorQueryResult>(response, headers, readResponseAsString: true, cancellationToken).ConfigureAwait(false);
                 if (anyResponse.Object?.Errors != null)
                 {
                     throw new FireboltStructuredException(anyResponse.Object.Errors);

--- a/FireboltNETSDK/FireboltClient.cs
+++ b/FireboltNETSDK/FireboltClient.cs
@@ -258,16 +258,19 @@ public abstract class FireboltClient
             foreach (var item in response.Content.Headers)
                 headers[item.Key] = item.Value;
 
-            try {
+            try
+            {
                 var anyResponse = await ReadObjectResponseAsync<JsonErrorQueryResult>(response, headers, readResponseAsString: true, cancellationToken).ConfigureAwait(false);
                 if (anyResponse.Object?.Errors != null)
                 {
                     throw new FireboltStructuredException(anyResponse.Object.Errors);
                 }
-            } catch (FireboltStructuredException exception)
+            }
+            catch (FireboltStructuredException exception)
             {
                 throw exception;
-            } catch (System.Exception)
+            }
+            catch (System.Exception)
             {
                 // Ignore any other parsing exceptions, we will handle them later.
             }

--- a/FireboltNETSDK/FireboltClient.cs
+++ b/FireboltNETSDK/FireboltClient.cs
@@ -25,6 +25,7 @@ using FireboltDotNetSdk.Utils;
 using Newtonsoft.Json;
 using FireboltDotNetSdk.Client;
 using static FireboltDotNetSdk.Client.FireResponse;
+using FireboltNETSDK.Exception;
 
 namespace FireboltDotNetSdk;
 
@@ -256,6 +257,12 @@ public abstract class FireboltClient
             var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value);
             foreach (var item in response.Content.Headers)
                 headers[item.Key] = item.Value;
+
+            var anyResponse = await ReadObjectResponseAsync<QueryResult>(response, headers, readResponseAsString: true, cancellationToken).ConfigureAwait(false);
+            if (anyResponse.Object?.Errors != null)
+            {
+                throw new FireboltStructuredException(anyResponse.Object.Errors);
+            }
 
             if (response.IsSuccessStatusCode)
             {

--- a/FireboltNETSDK/FireboltClient.cs
+++ b/FireboltNETSDK/FireboltClient.cs
@@ -258,10 +258,18 @@ public abstract class FireboltClient
             foreach (var item in response.Content.Headers)
                 headers[item.Key] = item.Value;
 
-            var anyResponse = await ReadObjectResponseAsync<QueryResult>(response, headers, readResponseAsString: true, cancellationToken).ConfigureAwait(false);
-            if (anyResponse.Object?.Errors != null)
+            try {
+                var anyResponse = await ReadObjectResponseAsync<QueryResult>(response, headers, readResponseAsString: true, cancellationToken).ConfigureAwait(false);
+                if (anyResponse.Object?.Errors != null)
+                {
+                    throw new FireboltStructuredException(anyResponse.Object.Errors);
+                }
+            } catch (FireboltStructuredException exception)
             {
-                throw new FireboltStructuredException(anyResponse.Object.Errors);
+                throw exception;
+            } catch (System.Exception)
+            {
+                // Ignore any other parsing exceptions, we will handle them later.
             }
 
             if (response.IsSuccessStatusCode)

--- a/FireboltNETSDK/Utils/JsonHelper.cs
+++ b/FireboltNETSDK/Utils/JsonHelper.cs
@@ -16,6 +16,9 @@ namespace FireboltDotNetSdk.Utils
         [JsonProperty("rows", NullValueHandling = NullValueHandling.Ignore)]
         public long? Rows { get; set; }
 
+        [JsonProperty("errors", NullValueHandling = NullValueHandling.Ignore)]
+        public List<StructuredError> Errors { get; set; } = null!;
+
         [JsonProperty("statistics", NullValueHandling = NullValueHandling.Ignore)]
         public Statistics Statistics { get; set; } = null!;
     }
@@ -57,6 +60,26 @@ namespace FireboltDotNetSdk.Utils
 
         [JsonProperty("scanned_bytes_storage", NullValueHandling = NullValueHandling.Ignore)]
         public long? ScannedBytesStorage { get; set; }
+    }
+
+
+    public class StructuredError
+    {
+        public string? Code { get; set; }
+        public string? Name { get; set; }
+        public string? Severity { get; set; }
+        public string? Source { get; set; }
+        public string? Description { get; set; }
+        public string? Resolution { get; set; }
+        public string? HelpLink { get; set; }
+        public Location? Location { get; set; }
+    }
+
+    public class Location
+    {
+        public int? FailingLine { get; set; }
+        public int? StartOffset { get; set; }
+        public int? EndOffset { get; set; }
     }
 }
 

--- a/FireboltNETSDK/Utils/JsonHelper.cs
+++ b/FireboltNETSDK/Utils/JsonHelper.cs
@@ -62,6 +62,11 @@ namespace FireboltDotNetSdk.Utils
         public long? ScannedBytesStorage { get; set; }
     }
 
+    public class JsonErrorQueryResult
+    {
+        [JsonProperty("errors", NullValueHandling = NullValueHandling.Ignore)]
+        public List<StructuredError> Errors { get; set; } = null!;
+    }
 
     public class StructuredError
     {


### PR DESCRIPTION
Changing other tests in order to be future-proof when JSON body error becomes the norm. We're only concerned that FireboltException or its subclasses are returned.