### PR TITLE
ci: Disable coverage report on main

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,6 +41,8 @@ jobs:
         path: /home/runner/work/firebolt-net-sdk/firebolt-net-sdk/FireboltDotNetSdk.Tests/coverage.xml
 
   coverage:
+    # Can't decorate a PR if there's no PR
+    if: ${{ github.event_name != 'push' }}
     needs: [unit-tests]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The action is meant to display a coverage report on a PR. However, this is not possible on a main branch and it fails needlessly, making us look bad.
Making it run only on workflow_call