### PR TITLE
test: remove multistatement query from system engine test

### DIFF
--- a/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/SystemEngineTest.cs
@@ -79,7 +79,9 @@ namespace FireboltDotNetSdk.Tests
         {
             try
             {
-                var command = CreateCommand("CREATE TABLE IF NOT EXISTS dummy(id INT); SELECT * FROM dummy");
+                var command = CreateCommand("CREATE TABLE IF NOT EXISTS dummy(id INT)");
+                command.ExecuteNonQuery();
+                command = CreateCommand("SELECT * FROM dummy");
                 string errorMessage = ((FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => { command.ExecuteNonQuery(); }))?.Response ?? "";
                 Assert.True(new Regex("Run this (query|statement) on a user engine.").Match(errorMessage).Success);
             }


### PR DESCRIPTION
.NET doesn't have a support for multistatement queries yet. Therefore, a system engine test, which has a multistatement sql query, started to fail. Manually splitted the query for now. We would need to implement client-side support for multistatements (https://packboard.atlassian.net/browse/FIR-35645)