### PR TITLE
feat(FIR-35472): remove account endpoint

### DIFF
--- a/FireboltDotNetSdk.Tests/Unit/FireboltClientTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltClientTest.cs
@@ -216,42 +216,6 @@ namespace FireboltDotNetSdk.Tests
         }
 
 
-        [Test]
-        public void UnauthorizedAccount()
-        {
-            string engineUrl = "http://api.test.firebolt.io";
-            Mock<HttpClient> httpClientMock = new Mock<HttpClient>();
-            LoginResponse loginResponse = new LoginResponse("access_token", "3600", "Bearer");
-            httpClientMock.SetupSequence(p => p.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(GetResponseMessage(loginResponse, HttpStatusCode.OK))
-            .ReturnsAsync(GetResponseMessage(new GetSystemEngineUrlResponse() { engineUrl = engineUrl }, HttpStatusCode.NotFound))
-            .ReturnsAsync(GetResponseMessage(new GetAccountIdByNameResponse(), HttpStatusCode.NotFound));
-            var connection = new FireboltConnection("database=testdb.ib;clientid=testuser;clientsecret=test_pwd;account=accountname");
-            FireboltClient2 client = new FireboltClient2(connection, Guid.NewGuid().ToString(), "password", "", "test", "account", httpClientMock.Object);
-
-            FireboltException? e = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => client.GetSystemEngineUrl("my_account").GetAwaiter().GetResult());
-            Assert.That(e?.Message, Does.StartWith($"Account 'my_account' does not exist"));
-
-            e = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => client.GetAccountIdByNameAsync("your_account", CancellationToken.None).GetAwaiter().GetResult());
-            Assert.That(e?.Message, Does.StartWith($"Account 'your_account' does not exist"));
-        }
-
-
-        [Test]
-        public async Task GetAccountIdByNameAsync()
-        {
-            Mock<HttpClient> httpClientMock = new Mock<HttpClient>();
-            LoginResponse loginResponse = new LoginResponse("access_token", "3600", "Bearer");
-            httpClientMock.SetupSequence(p => p.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(GetResponseMessage(loginResponse, HttpStatusCode.OK))
-            .ReturnsAsync(GetResponseMessage(new GetAccountIdByNameResponse() { id = "my_account_id" }, HttpStatusCode.OK));
-            var connection = new FireboltConnection(connectionString);
-            FireboltClient client = new FireboltClient1(connection, Guid.NewGuid().ToString(), "password", "", "test", "account", httpClientMock.Object);
-            GetAccountIdByNameResponse response = await client.GetAccountIdByNameAsync("my_account_name", CancellationToken.None);
-            Assert.That(response.id, Is.EqualTo("my_account_id"));
-            httpClientMock.Verify(m => m.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
-        }
-
         internal static HttpResponseMessage GetResponseMessage(object responseObject, HttpStatusCode httpStatusCode)
         {
             HttpResponseMessage response = GetResponseMessage(httpStatusCode);

--- a/FireboltNETSDK/FireboltClient.cs
+++ b/FireboltNETSDK/FireboltClient.cs
@@ -244,7 +244,7 @@ public abstract class FireboltClient
         //Add access token only when it is required for the request
         if (needsAccessToken)
         {
-            AddAccessToken(request);
+            await AddAccessToken(request);
         }
 
         var response = await _httpClient
@@ -416,7 +416,7 @@ public abstract class FireboltClient
         return shouldUpdateConnection;
     }
 
-    private async void AddAccessToken(HttpRequestMessage request)
+    private async Task AddAccessToken(HttpRequestMessage request)
     {
         if (string.IsNullOrEmpty(_token))
         {

--- a/FireboltNETSDK/FireboltClient.cs
+++ b/FireboltNETSDK/FireboltClient.cs
@@ -401,10 +401,6 @@ public abstract class FireboltClient
                         }
                         break;
                     case "account_id":
-                        if (!string.IsNullOrEmpty(_connection.AccountId) && !_connection.AccountId.Equals(kv[1]))
-                        {
-                            throw new FireboltException("Failed to execute command. Account parameter mismatch. Contact support");
-                        }
                         _connection.AccountId = kv[1];
                         break;
                     default:

--- a/FireboltNETSDK/FireboltClient2.cs
+++ b/FireboltNETSDK/FireboltClient2.cs
@@ -107,7 +107,7 @@ public class FireboltClient2 : FireboltClient
             systemEngineUrlCache[cacheKey] = systemEngineUrl;
             string[] urlParts = systemEngineUrl.Split('?');
             _connection.EngineUrl = urlParts[0];
-            string? accountId = _connection.AccountId; // initializes InfraVersion and connection.accountId
+            _connection.InfraVersion = 2;
             if (urlParts.Length > 1)
             {
                 ProcessParameters(new FireboltConnectionStringBuilder(_connection.ConnectionString), ExtractParameters(urlParts[1]), false);
@@ -239,6 +239,7 @@ public class FireboltClient2 : FireboltClient
     public override Task<GetAccountIdByNameResponse> GetAccountIdByNameAsync(string account, CancellationToken cancellationToken)
     {
         // For 2.0 this is a no-op as account id is fetched during use engine command
+        // Keeping this implementation since connection is independent of 1.0 and 2.0
         return Task.FromResult(new GetAccountIdByNameResponse() { id = null, infraVersion = 2 });
     }
 }

--- a/FireboltNETSDK/FireboltClient2.cs
+++ b/FireboltNETSDK/FireboltClient2.cs
@@ -107,6 +107,7 @@ public class FireboltClient2 : FireboltClient
             systemEngineUrlCache[cacheKey] = systemEngineUrl;
             string[] urlParts = systemEngineUrl.Split('?');
             _connection.EngineUrl = urlParts[0];
+            string? accountId = _connection.AccountId; // initializes InfraVersion and connection.accountId
             if (urlParts.Length > 1)
             {
                 ProcessParameters(new FireboltConnectionStringBuilder(_connection.ConnectionString), ExtractParameters(urlParts[1]), false);
@@ -238,6 +239,6 @@ public class FireboltClient2 : FireboltClient
     public override Task<GetAccountIdByNameResponse> GetAccountIdByNameAsync(string account, CancellationToken cancellationToken)
     {
         // For 2.0 this is a no-op as account id is fetched during use engine command
-        return Task.FromResult(new GetAccountIdByNameResponse() { id = null });
+        return Task.FromResult(new GetAccountIdByNameResponse() { id = null, infraVersion = 2 });
     }
 }

--- a/FireboltNETSDK/FireboltClient2.cs
+++ b/FireboltNETSDK/FireboltClient2.cs
@@ -40,21 +40,6 @@ public class FireboltClient2 : FireboltClient
         _account = account;
     }
 
-    /// <param name="account"></param>
-    /// <param name="cancellationToken">
-    ///     A cancellation token that can be used by other objects or threads to receive notice of
-    ///     cancellation.
-    /// </param>
-    /// <summary>
-    ///     Returns Account id by account name given.
-    /// </summary>
-    /// <returns>A successful response.</returns>
-    /// <exception cref="FireboltException">A server side error occurred.</exception>
-    public override async Task<GetAccountIdByNameResponse> GetAccountIdByNameAsync(string accountName, CancellationToken cancellationToken)
-    {
-        return await GetAccountField<GetAccountIdByNameResponse>("resolve", accountName);
-    }
-
     /// <summary>
     ///     Authenticates the user with Firebolt.
     /// </summary>
@@ -122,7 +107,6 @@ public class FireboltClient2 : FireboltClient
             systemEngineUrlCache[cacheKey] = systemEngineUrl;
             string[] urlParts = systemEngineUrl.Split('?');
             _connection.EngineUrl = urlParts[0];
-            string? accountId = _connection.AccountId; // initializes InfraVersion and connection.accountId
             if (urlParts.Length > 1)
             {
                 ProcessParameters(new FireboltConnectionStringBuilder(_connection.ConnectionString), ExtractParameters(urlParts[1]), false);
@@ -251,4 +235,9 @@ public class FireboltClient2 : FireboltClient
         systemEngineUrlCache.Clear();
     }
 
+    public override Task<GetAccountIdByNameResponse> GetAccountIdByNameAsync(string account, CancellationToken cancellationToken)
+    {
+        // For 2.0 this is a no-op as account id is fetched during use engine command
+        return Task.FromResult(new GetAccountIdByNameResponse() { id = null });
+    }
 }


### PR DESCRIPTION
Remove the resolve endpoint that's no longer used for Firebolt 2.0.
There's still a lot of code dependant on infra version and even on account id. Namely, Statement and Connection classes are 1.0/2.0 independent and id resolution is needed on 1.0. Refactoring it out should be a part of a separate effort, including retiring infrastructure version.

Removed tests are either obsolete or test account version 1, which is no longer used. They were relying on default behaviour, which is no longer present.

Tests are passing to the same level as in main - 3 tests for FB2.0 are currently broken and should be investigated.
Similarly, sonarcloud issues require larger effort of fixing the code in main.