### PR TITLE
feat(FIR-42861): Server-side async support

### DIFF
--- a/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
@@ -40,7 +40,7 @@ namespace FireboltDotNetSdk.Tests
 
         [Test]
         [Category("engine-v2")]
-        public async Task ExecuteAsyncNonQueryTest()
+        public async Task ExecuteServerSideAsyncNonQueryTest()
         {
 
             using var connection = new FireboltConnection(USER_CONNECTION_STRING);
@@ -50,7 +50,7 @@ namespace FireboltDotNetSdk.Tests
             FireboltCommand command = (FireboltCommand)connection.CreateCommand();
             command.CommandText = $"INSERT INTO {_tableName} SELECT checksum(*) FROM GENERATE_SERIES(1, 2500000000)";
 
-            await command.ExecuteAsyncNonQueryAsync();
+            await command.ExecuteServerSideAsyncNonQueryAsync();
 
             string? token = command.AsyncToken;
 
@@ -60,14 +60,14 @@ namespace FireboltDotNetSdk.Tests
             Assert.That(token.Length, Is.GreaterThan(0));
 
             // Check that the query status is initially running
-            Assert.That(await connection.IsAsyncQueryRunningAsync(token), Is.True);
+            Assert.That(await connection.IsServerSideAsyncQueryRunningAsync(token), Is.True);
 
             // Wait a bit for the query to make progress
             await Task.Delay(5000);
 
             // Check the status again - it should be finished
-            Assert.That(await connection.IsAsyncQueryRunningAsync(token), Is.False);
-            Assert.That(await connection.IsAsyncQuerySuccessfulAsync(token), Is.True);
+            Assert.That(await connection.IsServerSideAsyncQueryRunningAsync(token), Is.False);
+            Assert.That(await connection.IsServerSideAsyncQuerySuccessfulAsync(token), Is.True);
 
             // Verify the data was written to the table
             DbCommand countCommand = connection.CreateCommand();
@@ -78,7 +78,7 @@ namespace FireboltDotNetSdk.Tests
 
         [Test]
         [Category("engine-v2")]
-        public void ExecuteAsyncNonQuerySyncTest()
+        public void ExecuteServerSideAsyncNonQuerySyncTest()
         {
             using var connection = new FireboltConnection(USER_CONNECTION_STRING);
             connection.Open();
@@ -88,7 +88,7 @@ namespace FireboltDotNetSdk.Tests
             command.CommandText = $"INSERT INTO {_tableName} SELECT checksum(*) FROM GENERATE_SERIES(1, 2500000000)";
 
             // Execute the query asynchronously using the synchronous method
-            command.ExecuteAsyncNonQuery();
+            command.ExecuteServerSideAsyncNonQuery();
 
             string? token = command.AsyncToken;
 
@@ -101,7 +101,7 @@ namespace FireboltDotNetSdk.Tests
             });
 
             // Check that the query status is initially running
-            Assert.That(connection.IsAsyncQueryRunning(token), Is.True);
+            Assert.That(connection.IsServerSideAsyncQueryRunning(token), Is.True);
 
             // Wait a bit for the query to make progress
             Task.Delay(5000).Wait();
@@ -109,8 +109,8 @@ namespace FireboltDotNetSdk.Tests
             // Check the status again - it should be finished
             Assert.Multiple(() =>
             {
-                Assert.That(connection.IsAsyncQueryRunning(token), Is.False);
-                Assert.That(connection.IsAsyncQuerySuccessful(token), Is.True);
+                Assert.That(connection.IsServerSideAsyncQueryRunning(token), Is.False);
+                Assert.That(connection.IsServerSideAsyncQuerySuccessful(token), Is.True);
             });
 
             // Verify the data was written to the table
@@ -122,7 +122,7 @@ namespace FireboltDotNetSdk.Tests
 
         [Test]
         [Category("engine-v2")]
-        public async Task CancelAsyncQueryTest()
+        public async Task CancelServerSideAsyncQueryTest()
         {
             using var connection = new FireboltConnection(USER_CONNECTION_STRING);
             await connection.OpenAsync();
@@ -131,7 +131,7 @@ namespace FireboltDotNetSdk.Tests
             FireboltCommand command = (FireboltCommand)connection.CreateCommand();
             command.CommandText = $"INSERT INTO {_tableName} SELECT checksum(*) FROM GENERATE_SERIES(1, 5000000000)";
 
-            await command.ExecuteAsyncNonQueryAsync();
+            await command.ExecuteServerSideAsyncNonQueryAsync();
             string? token = command.AsyncToken;
             Assert.That(token, Is.Not.Null);
 
@@ -139,15 +139,15 @@ namespace FireboltDotNetSdk.Tests
             await Task.Delay(1000);
 
             // Verify the query is running
-            bool isRunning = await connection.IsAsyncQueryRunningAsync(token);
+            bool isRunning = await connection.IsServerSideAsyncQueryRunningAsync(token);
             Assert.That(isRunning, Is.True, "Query should be running before cancellation");
 
             // Stop the query
-            bool stopped = await connection.CancelAsyncQueryAsync(token);
+            bool stopped = await connection.CancelServerSideAsyncQueryAsync(token);
             Assert.That(stopped, Is.True, "Failed to stop the async query");
 
             // Verify the query is no longer running
-            isRunning = await connection.IsAsyncQueryRunningAsync(token);
+            isRunning = await connection.IsServerSideAsyncQueryRunningAsync(token);
             Assert.That(isRunning, Is.False, "Query should no longer be running");
 
             // Verify no data was written to the table

--- a/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
@@ -13,14 +13,14 @@ namespace FireboltDotNetSdk.Tests
         public new void SetUp()
         {
             base.SetUp();
-            
+
             // Generate a unique table name for each test
             _tableName = $"async_test_table_{Guid.NewGuid().ToString("N").Substring(0, 8)}";
-            
+
             // Create a connection specifically for setup
             using var setupConnection = new FireboltConnection(USER_CONNECTION_STRING);
             setupConnection.Open();
-            
+
             // Create test table
             FireboltCommand createTableCommand = (FireboltCommand)setupConnection.CreateCommand();
             createTableCommand.CommandText = $"CREATE TABLE IF NOT EXISTS {_tableName} (id bigint)";
@@ -33,7 +33,7 @@ namespace FireboltDotNetSdk.Tests
             // Create a connection specifically for teardown
             using var teardownConnection = new FireboltConnection(USER_CONNECTION_STRING);
             teardownConnection.Open();
-            
+
             // Drop test table
             DbCommand dropTableCommand = teardownConnection.CreateCommand();
             dropTableCommand.CommandText = $"DROP TABLE IF EXISTS {_tableName}";

--- a/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
@@ -1,0 +1,194 @@
+using System.Data.Common;
+using FireboltDotNetSdk.Client;
+
+namespace FireboltDotNetSdk.Tests
+{
+    [TestFixture]
+    internal class AsyncQueryTest : IntegrationTest
+    {
+        private static string USER_CONNECTION_STRING = ConnectionString();
+
+        [Test]
+        [Category("engine-v2")]
+        public async Task ExecuteAsyncQueryTest()
+        {
+            using var conn = new FireboltConnection(USER_CONNECTION_STRING);
+            conn.Open();
+
+            try
+            {
+                // Create command to create a table
+                FireboltCommand createTableCommand = (FireboltCommand)conn.CreateCommand();
+                createTableCommand.CommandText = "CREATE TABLE IF NOT EXISTS async_test_table (id bigint)";
+                await createTableCommand.ExecuteNonQueryAsync();
+
+                // Create command with a computationally intensive query
+                FireboltCommand command = (FireboltCommand)conn.CreateCommand();
+                command.CommandText = "INSERT INTO async_test_table SELECT checksum(*) FROM GENERATE_SERIES(1, 2500000000)";
+
+                // Execute the query asynchronously
+                string token = await command.ExecuteAsyncQueryAsync();
+
+                // Verify we received a token
+                Assert.NotNull(token);
+                Assert.IsFalse(string.IsNullOrEmpty(token));
+
+                // Verify the token is stored in the command
+                Assert.That(command.AsyncToken, Is.EqualTo(token));
+
+                // Check the token format (should be non-empty string)
+                Assert.That(token.Length, Is.GreaterThan(0));
+
+                // Check that the query status is initially RUNNING or QUEUED
+                var initialStatusInfo = await conn.GetAsyncQueryStatusAsync(token);
+                Assert.That(initialStatusInfo.ContainsKey("status"), Is.True);
+                Assert.That(initialStatusInfo["status"], Is.EqualTo("RUNNING"));
+                Assert.That(await conn.IsAsyncQueryRunningAsync(token), Is.True);
+
+                // Wait a bit for the query to make progress
+                await Task.Delay(5000);
+
+                // Check the status again - still should be running or possibly finished
+                var laterStatusInfo = await conn.GetAsyncQueryStatusAsync(token);
+                Assert.That(laterStatusInfo.ContainsKey("status"), Is.True);
+                Assert.That(laterStatusInfo["status"], Is.EqualTo("ENDED_SUCCESSFULLY"));
+
+                Assert.That(await conn.IsAsyncQueryRunningAsync(token), Is.False);
+                Assert.That(await conn.IsAsyncQuerySuccessfulAsync(token), Is.True);
+                
+                // Verify the data was written to the table
+                DbCommand countCommand = conn.CreateCommand();
+                countCommand.CommandText = "SELECT COUNT(*) FROM async_test_table";
+                var count = await countCommand.ExecuteScalarAsync();
+                Assert.That(count, Is.EqualTo(1));
+            }
+            finally
+            {
+                // drop test table - will run even if previous commands fail
+                DbCommand dropTableCommand = conn.CreateCommand();
+                dropTableCommand.CommandText = "DROP TABLE IF EXISTS async_test_table";
+                await dropTableCommand.ExecuteNonQueryAsync();
+            }
+        }
+
+        [Test]
+        [Category("engine-v2")]
+        public void ExecuteAsyncQuerySyncTest()
+        {
+            using var conn = new FireboltConnection(USER_CONNECTION_STRING);
+            conn.Open();
+
+            try
+            {
+                // Create command to create a table
+                FireboltCommand createTableCommand = (FireboltCommand)conn.CreateCommand();
+                createTableCommand.CommandText = "CREATE TABLE IF NOT EXISTS async_test_table_sync (id bigint)";
+                createTableCommand.ExecuteNonQuery();
+
+                // Create command with a computationally intensive query
+                FireboltCommand command = (FireboltCommand)conn.CreateCommand();
+                command.CommandText = "INSERT INTO async_test_table_sync SELECT checksum(*) FROM GENERATE_SERIES(1, 2500000000)";
+
+                // Execute the query asynchronously using the synchronous method
+                string token = command.ExecuteAsyncQuery();
+
+                // Verify we received a token
+                Assert.NotNull(token);
+                Assert.IsFalse(string.IsNullOrEmpty(token));
+
+                // Verify the token is stored in the command
+                Assert.That(command.AsyncToken, Is.EqualTo(token));
+
+                // Check the token format (should be non-empty string)
+                Assert.That(token.Length, Is.GreaterThan(0));
+
+                // Check that the query status is initially RUNNING or QUEUED
+                var initialStatusInfo = conn.GetAsyncQueryStatus(token);
+                Assert.That(initialStatusInfo.ContainsKey("status"), Is.True);
+                Assert.That(initialStatusInfo["status"], Is.EqualTo("RUNNING"));
+                Assert.That(conn.IsAsyncQueryRunning(token), Is.True);
+
+                // Wait a bit for the query to make progress
+                Thread.Sleep(5000);
+
+                // Check the status again - still should be running or possibly finished
+                var laterStatusInfo = conn.GetAsyncQueryStatus(token);
+                Assert.That(laterStatusInfo.ContainsKey("status"), Is.True);
+                Assert.That(laterStatusInfo["status"], Is.EqualTo("ENDED_SUCCESSFULLY"));
+                Assert.That(conn.IsAsyncQueryRunning(token), Is.False);
+                Assert.That(conn.IsAsyncQuerySuccessful(token), Is.True);
+
+                // Verify the data was written to the table
+                DbCommand countCommand = conn.CreateCommand();
+                countCommand.CommandText = "SELECT COUNT(*) FROM async_test_table_sync";
+                var count = countCommand.ExecuteScalar();
+                Assert.That(count, Is.EqualTo(1));
+            }
+            finally
+            {
+                // drop test table - will run even if previous commands fail
+                DbCommand dropTableCommand = conn.CreateCommand();
+                dropTableCommand.CommandText = "DROP TABLE IF EXISTS async_test_table_sync";
+                dropTableCommand.ExecuteNonQuery();
+            }
+        }
+
+        [Test]
+        [Category("engine-v2")]
+        public async Task CancelAsyncQueryTest()
+        {
+            using var conn = new FireboltConnection(USER_CONNECTION_STRING);
+            conn.Open();
+            
+            try
+            {
+                // Create command to create a table
+                FireboltCommand createTableCommand = (FireboltCommand)conn.CreateCommand();
+                createTableCommand.CommandText = "CREATE TABLE IF NOT EXISTS async_test_table_cancel (id bigint)";
+                await createTableCommand.ExecuteNonQueryAsync();
+
+                // Create command with a computationally intensive query that will take a while
+                FireboltCommand command = (FireboltCommand)conn.CreateCommand();
+                command.CommandText = "INSERT INTO async_test_table_cancel SELECT checksum(*) FROM GENERATE_SERIES(1, 5000000000)";
+
+                // Execute the query asynchronously
+                string token = await command.ExecuteAsyncQueryAsync();
+                Assert.NotNull(token);
+                
+                // Wait a moment to make sure the query starts running
+                await Task.Delay(1000);
+                
+                // Verify the query is running
+                var initialStatus = await conn.GetAsyncQueryStatusAsync(token);
+                Assert.That(initialStatus.ContainsKey("status"), Is.True);
+                Assert.That(initialStatus["status"], Is.EqualTo("RUNNING"));
+                
+                // Stop the query
+                bool stopped = await conn.CancelAsyncQueryAsync(token);
+                Assert.That(stopped, Is.True, "Failed to stop the async query");
+                
+                // Verify the query is no longer running
+                var updatedStatus = await conn.GetAsyncQueryStatusAsync(token);
+                Assert.That(updatedStatus.ContainsKey("status"), Is.True);
+                Assert.That(updatedStatus["status"], Is.Not.EqualTo("RUNNING"));
+                
+                // Verify using the helper method
+                bool running = await conn.IsAsyncQueryRunningAsync(token);
+                Assert.That(running, Is.False, "Query should no longer be running");
+
+                // Verify no data was written to the table
+                DbCommand countCommand = conn.CreateCommand();
+                countCommand.CommandText = "SELECT COUNT(*) FROM async_test_table_cancel";
+                var count = await countCommand.ExecuteScalarAsync();
+                Assert.That(count, Is.EqualTo(0));
+            }
+            finally
+            {
+                // drop test table - will run even if previous commands fail
+                DbCommand dropTableCommand = conn.CreateCommand();
+                dropTableCommand.CommandText = "DROP TABLE IF EXISTS async_test_table_cancel";
+                await dropTableCommand.ExecuteNonQueryAsync();
+            }
+        }
+    }
+}

--- a/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
@@ -33,8 +33,8 @@ namespace FireboltDotNetSdk.Tests
                 string? token = command.AsyncToken;
 
                 // Verify we received a token
-                Assert.NotNull(token);
-                Assert.IsFalse(string.IsNullOrEmpty(token));
+                Assert.That(token, Is.Not.Null);
+                Assert.That(string.IsNullOrEmpty(token), Is.False);
 
                 // Check the token format (should be non-empty string)
                 Assert.That(token.Length, Is.GreaterThan(0));
@@ -89,8 +89,8 @@ namespace FireboltDotNetSdk.Tests
                 string? token = command.AsyncToken;
 
                 // Verify we received a token
-                Assert.NotNull(token);
-                Assert.IsFalse(string.IsNullOrEmpty(token));
+                Assert.That(token, Is.Not.Null);
+                Assert.That(string.IsNullOrEmpty(token), Is.False);
 
                 // Check the token format (should be non-empty string)
                 Assert.That(token.Length, Is.GreaterThan(0));
@@ -141,7 +141,7 @@ namespace FireboltDotNetSdk.Tests
                 // Execute the query asynchronously
                 await command.ExecuteAsyncNonQueryAsync();
                 string? token = command.AsyncToken;
-                Assert.NotNull(token);
+                Assert.That(token, Is.Not.Null);
 
                 // Wait a moment to make sure the query starts running
                 await Task.Delay(1000);

--- a/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
@@ -13,7 +13,7 @@ namespace FireboltDotNetSdk.Tests
         public async Task ExecuteAsyncNonQueryTest()
         {
             using var conn = new FireboltConnection(USER_CONNECTION_STRING);
-            conn.Open();
+            await conn.OpenAsync();
 
             try
             {
@@ -26,17 +26,13 @@ namespace FireboltDotNetSdk.Tests
                 FireboltCommand command = (FireboltCommand)conn.CreateCommand();
                 command.CommandText = "INSERT INTO async_test_table SELECT checksum(*) FROM GENERATE_SERIES(1, 2500000000)";
 
-                // Execute the query asynchronously
                 await command.ExecuteAsyncNonQueryAsync();
 
-                // Retrieve the token from the command
                 string? token = command.AsyncToken;
 
                 // Verify we received a token
                 Assert.That(token, Is.Not.Null);
                 Assert.That(string.IsNullOrEmpty(token), Is.False);
-
-                // Check the token format (should be non-empty string)
                 Assert.That(token.Length, Is.GreaterThan(0));
 
                 // Check that the query status is initially running
@@ -45,7 +41,7 @@ namespace FireboltDotNetSdk.Tests
                 // Wait a bit for the query to make progress
                 await Task.Delay(5000);
 
-                // Check the status again - it should finished
+                // Check the status again - it should be finished
                 Assert.That(await conn.IsAsyncQueryRunningAsync(token), Is.False);
                 Assert.That(await conn.IsAsyncQuerySuccessfulAsync(token), Is.True);
 
@@ -57,7 +53,6 @@ namespace FireboltDotNetSdk.Tests
             }
             finally
             {
-                // drop test table - will run even if previous commands fail
                 DbCommand dropTableCommand = conn.CreateCommand();
                 dropTableCommand.CommandText = "DROP TABLE IF EXISTS async_test_table";
                 await dropTableCommand.ExecuteNonQueryAsync();
@@ -85,23 +80,20 @@ namespace FireboltDotNetSdk.Tests
                 // Execute the query asynchronously using the synchronous method
                 command.ExecuteAsyncNonQuery();
 
-                // Retrieve the token from the command
                 string? token = command.AsyncToken;
 
                 // Verify we received a token
                 Assert.That(token, Is.Not.Null);
                 Assert.That(string.IsNullOrEmpty(token), Is.False);
-
-                // Check the token format (should be non-empty string)
                 Assert.That(token.Length, Is.GreaterThan(0));
 
                 // Check that the query status is initially running
                 Assert.That(conn.IsAsyncQueryRunning(token), Is.True);
 
                 // Wait a bit for the query to make progress
-                Thread.Sleep(5000);
+                Task.Delay(5000).Wait();
 
-                // Check the status again - it should finished
+                // Check the status again - it should be finished
                 Assert.That(conn.IsAsyncQueryRunning(token), Is.False);
                 Assert.That(conn.IsAsyncQuerySuccessful(token), Is.True);
 
@@ -113,7 +105,6 @@ namespace FireboltDotNetSdk.Tests
             }
             finally
             {
-                // drop test table - will run even if previous commands fail
                 DbCommand dropTableCommand = conn.CreateCommand();
                 dropTableCommand.CommandText = "DROP TABLE IF EXISTS async_test_table_sync";
                 dropTableCommand.ExecuteNonQuery();
@@ -125,7 +116,7 @@ namespace FireboltDotNetSdk.Tests
         public async Task CancelAsyncQueryTest()
         {
             using var conn = new FireboltConnection(USER_CONNECTION_STRING);
-            conn.Open();
+            await conn.OpenAsync();
 
             try
             {
@@ -138,7 +129,6 @@ namespace FireboltDotNetSdk.Tests
                 FireboltCommand command = (FireboltCommand)conn.CreateCommand();
                 command.CommandText = "INSERT INTO async_test_table_cancel SELECT checksum(*) FROM GENERATE_SERIES(1, 5000000000)";
 
-                // Execute the query asynchronously
                 await command.ExecuteAsyncNonQueryAsync();
                 string? token = command.AsyncToken;
                 Assert.That(token, Is.Not.Null);
@@ -166,7 +156,6 @@ namespace FireboltDotNetSdk.Tests
             }
             finally
             {
-                // drop test table - will run even if previous commands fail
                 DbCommand dropTableCommand = conn.CreateCommand();
                 dropTableCommand.CommandText = "DROP TABLE IF EXISTS async_test_table_cancel";
                 await dropTableCommand.ExecuteNonQueryAsync();

--- a/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
@@ -10,7 +10,7 @@ namespace FireboltDotNetSdk.Tests
 
         [Test]
         [Category("engine-v2")]
-        public async Task ExecuteAsyncQueryTest()
+        public async Task ExecuteAsyncNonQueryTest()
         {
             using var conn = new FireboltConnection(USER_CONNECTION_STRING);
             conn.Open();
@@ -27,35 +27,28 @@ namespace FireboltDotNetSdk.Tests
                 command.CommandText = "INSERT INTO async_test_table SELECT checksum(*) FROM GENERATE_SERIES(1, 2500000000)";
 
                 // Execute the query asynchronously
-                string token = await command.ExecuteAsyncQueryAsync();
+                await command.ExecuteAsyncNonQueryAsync();
+
+                // Retrieve the token from the command
+                string? token = command.AsyncToken;
 
                 // Verify we received a token
                 Assert.NotNull(token);
                 Assert.IsFalse(string.IsNullOrEmpty(token));
 
-                // Verify the token is stored in the command
-                Assert.That(command.AsyncToken, Is.EqualTo(token));
-
                 // Check the token format (should be non-empty string)
                 Assert.That(token.Length, Is.GreaterThan(0));
 
-                // Check that the query status is initially RUNNING or QUEUED
-                var initialStatusInfo = await conn.GetAsyncQueryStatusAsync(token);
-                Assert.That(initialStatusInfo.ContainsKey("status"), Is.True);
-                Assert.That(initialStatusInfo["status"], Is.EqualTo("RUNNING"));
+                // Check that the query status is initially running
                 Assert.That(await conn.IsAsyncQueryRunningAsync(token), Is.True);
 
                 // Wait a bit for the query to make progress
                 await Task.Delay(5000);
 
-                // Check the status again - still should be running or possibly finished
-                var laterStatusInfo = await conn.GetAsyncQueryStatusAsync(token);
-                Assert.That(laterStatusInfo.ContainsKey("status"), Is.True);
-                Assert.That(laterStatusInfo["status"], Is.EqualTo("ENDED_SUCCESSFULLY"));
-
+                // Check the status again - it should finished
                 Assert.That(await conn.IsAsyncQueryRunningAsync(token), Is.False);
                 Assert.That(await conn.IsAsyncQuerySuccessfulAsync(token), Is.True);
-                
+
                 // Verify the data was written to the table
                 DbCommand countCommand = conn.CreateCommand();
                 countCommand.CommandText = "SELECT COUNT(*) FROM async_test_table";
@@ -73,7 +66,7 @@ namespace FireboltDotNetSdk.Tests
 
         [Test]
         [Category("engine-v2")]
-        public void ExecuteAsyncQuerySyncTest()
+        public void ExecuteAsyncNonQuerySyncTest()
         {
             using var conn = new FireboltConnection(USER_CONNECTION_STRING);
             conn.Open();
@@ -90,31 +83,25 @@ namespace FireboltDotNetSdk.Tests
                 command.CommandText = "INSERT INTO async_test_table_sync SELECT checksum(*) FROM GENERATE_SERIES(1, 2500000000)";
 
                 // Execute the query asynchronously using the synchronous method
-                string token = command.ExecuteAsyncQuery();
+                command.ExecuteAsyncNonQuery();
+
+                // Retrieve the token from the command
+                string? token = command.AsyncToken;
 
                 // Verify we received a token
                 Assert.NotNull(token);
                 Assert.IsFalse(string.IsNullOrEmpty(token));
 
-                // Verify the token is stored in the command
-                Assert.That(command.AsyncToken, Is.EqualTo(token));
-
                 // Check the token format (should be non-empty string)
                 Assert.That(token.Length, Is.GreaterThan(0));
 
-                // Check that the query status is initially RUNNING or QUEUED
-                var initialStatusInfo = conn.GetAsyncQueryStatus(token);
-                Assert.That(initialStatusInfo.ContainsKey("status"), Is.True);
-                Assert.That(initialStatusInfo["status"], Is.EqualTo("RUNNING"));
+                // Check that the query status is initially running
                 Assert.That(conn.IsAsyncQueryRunning(token), Is.True);
 
                 // Wait a bit for the query to make progress
                 Thread.Sleep(5000);
 
-                // Check the status again - still should be running or possibly finished
-                var laterStatusInfo = conn.GetAsyncQueryStatus(token);
-                Assert.That(laterStatusInfo.ContainsKey("status"), Is.True);
-                Assert.That(laterStatusInfo["status"], Is.EqualTo("ENDED_SUCCESSFULLY"));
+                // Check the status again - it should finished
                 Assert.That(conn.IsAsyncQueryRunning(token), Is.False);
                 Assert.That(conn.IsAsyncQuerySuccessful(token), Is.True);
 
@@ -139,7 +126,7 @@ namespace FireboltDotNetSdk.Tests
         {
             using var conn = new FireboltConnection(USER_CONNECTION_STRING);
             conn.Open();
-            
+
             try
             {
                 // Create command to create a table
@@ -152,29 +139,24 @@ namespace FireboltDotNetSdk.Tests
                 command.CommandText = "INSERT INTO async_test_table_cancel SELECT checksum(*) FROM GENERATE_SERIES(1, 5000000000)";
 
                 // Execute the query asynchronously
-                string token = await command.ExecuteAsyncQueryAsync();
+                await command.ExecuteAsyncNonQueryAsync();
+                string? token = command.AsyncToken;
                 Assert.NotNull(token);
-                
+
                 // Wait a moment to make sure the query starts running
                 await Task.Delay(1000);
-                
+
                 // Verify the query is running
-                var initialStatus = await conn.GetAsyncQueryStatusAsync(token);
-                Assert.That(initialStatus.ContainsKey("status"), Is.True);
-                Assert.That(initialStatus["status"], Is.EqualTo("RUNNING"));
-                
+                bool isRunning = await conn.IsAsyncQueryRunningAsync(token);
+                Assert.That(isRunning, Is.True, "Query should be running before cancellation");
+
                 // Stop the query
                 bool stopped = await conn.CancelAsyncQueryAsync(token);
                 Assert.That(stopped, Is.True, "Failed to stop the async query");
-                
+
                 // Verify the query is no longer running
-                var updatedStatus = await conn.GetAsyncQueryStatusAsync(token);
-                Assert.That(updatedStatus.ContainsKey("status"), Is.True);
-                Assert.That(updatedStatus["status"], Is.Not.EqualTo("RUNNING"));
-                
-                // Verify using the helper method
-                bool running = await conn.IsAsyncQueryRunningAsync(token);
-                Assert.That(running, Is.False, "Query should no longer be running");
+                isRunning = await conn.IsAsyncQueryRunningAsync(token);
+                Assert.That(isRunning, Is.False, "Query should no longer be running");
 
                 // Verify no data was written to the table
                 DbCommand countCommand = conn.CreateCommand();

--- a/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/AsyncQueryTest.cs
@@ -17,7 +17,6 @@ namespace FireboltDotNetSdk.Tests
             // Generate a unique table name for each test
             _tableName = $"async_test_table_{Guid.NewGuid().ToString("N").Substring(0, 8)}";
 
-            // Create a connection specifically for setup
             using var setupConnection = new FireboltConnection(USER_CONNECTION_STRING);
             setupConnection.Open();
 
@@ -30,7 +29,6 @@ namespace FireboltDotNetSdk.Tests
         [TearDown]
         public void TearDown()
         {
-            // Create a connection specifically for teardown
             using var teardownConnection = new FireboltConnection(USER_CONNECTION_STRING);
             teardownConnection.Open();
 
@@ -44,7 +42,7 @@ namespace FireboltDotNetSdk.Tests
         [Category("engine-v2")]
         public async Task ExecuteAsyncNonQueryTest()
         {
-            // Create a separate connection for the test
+
             using var connection = new FireboltConnection(USER_CONNECTION_STRING);
             await connection.OpenAsync();
 
@@ -82,7 +80,6 @@ namespace FireboltDotNetSdk.Tests
         [Category("engine-v2")]
         public void ExecuteAsyncNonQuerySyncTest()
         {
-            // Create a separate connection for the test
             using var connection = new FireboltConnection(USER_CONNECTION_STRING);
             connection.Open();
 
@@ -97,8 +94,11 @@ namespace FireboltDotNetSdk.Tests
 
             // Verify we received a token
             Assert.That(token, Is.Not.Null);
-            Assert.That(string.IsNullOrEmpty(token), Is.False);
-            Assert.That(token.Length, Is.GreaterThan(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(string.IsNullOrEmpty(token), Is.False);
+                Assert.That(token.Length, Is.GreaterThan(0));
+            });
 
             // Check that the query status is initially running
             Assert.That(connection.IsAsyncQueryRunning(token), Is.True);
@@ -107,8 +107,11 @@ namespace FireboltDotNetSdk.Tests
             Task.Delay(5000).Wait();
 
             // Check the status again - it should be finished
-            Assert.That(connection.IsAsyncQueryRunning(token), Is.False);
-            Assert.That(connection.IsAsyncQuerySuccessful(token), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(connection.IsAsyncQueryRunning(token), Is.False);
+                Assert.That(connection.IsAsyncQuerySuccessful(token), Is.True);
+            });
 
             // Verify the data was written to the table
             DbCommand countCommand = connection.CreateCommand();
@@ -121,7 +124,6 @@ namespace FireboltDotNetSdk.Tests
         [Category("engine-v2")]
         public async Task CancelAsyncQueryTest()
         {
-            // Create a separate connection for the test
             using var connection = new FireboltConnection(USER_CONNECTION_STRING);
             await connection.OpenAsync();
 

--- a/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
@@ -73,7 +73,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var connection = new FireboltConnection(mockConnectionString) { Client = new MockClient("{}"), EngineUrl = "engine" };
             var cs = new FireboltCommand(connection, commandText, new FireboltParameterCollection());
-            Assert.IsEmpty(cs.SetParamList);
+            Assert.That(cs.SetParamList, Is.Empty);
             cs.ExecuteNonQuery();
             Assert.That(cs.SetParamList, Is.EqualTo(new HashSet<string>(new string[] { commandText.Replace("SET ", "") })));
         }
@@ -84,7 +84,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var connection = new FireboltConnection(mockConnectionString) { Client = new MockClient("{}"), EngineUrl = "engine" };
             var cs = new FireboltCommand(connection, commandText, new FireboltParameterCollection());
-            Assert.IsEmpty(cs.SetParamList);
+            Assert.That(cs.SetParamList, Is.Empty);
             await cs.ExecuteNonQueryAsync();
             Assert.That(cs.SetParamList, Is.EqualTo(new HashSet<string>(new string[] { commandText.Replace("SET ", "") })));
         }
@@ -109,7 +109,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var cs = new FireboltCommand { CommandText = commandText };
             FireboltException? exception = (FireboltException?)Assert.Throws(Is.InstanceOf<FireboltException>(), () => cs.ExecuteReader());
-            Assert.NotNull(exception);
+            Assert.That(exception, Is.Not.Null);
             Assert.That(exception!.Message, Is.EqualTo("Unable to execute SQL as no connection was initialised. Create command using working connection"));
         }
 
@@ -118,7 +118,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var cs = createCommand("select 1", null);
             DbDataReader reader = cs.ExecuteReader();
-            Assert.False(reader.Read());
+            Assert.That(reader.Read(), Is.False);
         }
 
         [TestCase(null, null, "SQL command is null")]
@@ -138,12 +138,12 @@ namespace FireboltDotNetSdk.Tests
 
             var cs = createCommand("select 1", response);
             DbDataReader reader = cs.ExecuteReader();
-            Assert.True(reader.Read());
+            Assert.That(reader.Read(), Is.True);
             Assert.That(reader.GetInt16(0), Is.EqualTo(1));
             Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(int)));
             Assert.That(reader.GetDouble(1), Is.EqualTo(double.PositiveInfinity));
             Assert.That(reader.GetFieldType(1), Is.EqualTo(typeof(double)));
-            Assert.False(reader.Read());
+            Assert.That(reader.Read(), Is.False);
         }
 
         [Test]
@@ -163,11 +163,11 @@ namespace FireboltDotNetSdk.Tests
             var cs = new FireboltCommand(connection, commandText, new FireboltParameterCollection());
 
             cs.ExecuteNonQuery();
-            Assert.IsNotEmpty(cs.SetParamList);
-            Assert.IsNotEmpty(connection.SetParamList);
+            Assert.That(cs.SetParamList, Is.Not.Empty);
+            Assert.That(connection.SetParamList, Is.Not.Empty);
             cs.ClearSetList();
-            Assert.IsEmpty(cs.SetParamList);
-            Assert.IsEmpty(connection.SetParamList);
+            Assert.That(cs.SetParamList, Is.Empty);
+            Assert.That(connection.SetParamList, Is.Empty);
         }
 
         [Test]
@@ -175,7 +175,7 @@ namespace FireboltDotNetSdk.Tests
         {
             var cs = new FireboltCommand();
             cs.Parameters.Add(new FireboltParameter("@param", "abcd"));
-            Assert.IsTrue(cs.Parameters.Any());
+            Assert.That(cs.Parameters.Any(), Is.True);
         }
 
         [TestCase("hello")]
@@ -190,7 +190,7 @@ namespace FireboltDotNetSdk.Tests
             parameter.ParameterName = "@param";
             parameter.Value = value;
             cs.Parameters.Add(parameter);
-            Assert.IsTrue(cs.Parameters.Any());
+            Assert.That(cs.Parameters.Any(), Is.True);
         }
 
         [Test]
@@ -395,13 +395,13 @@ namespace FireboltDotNetSdk.Tests
         public void SetDesignTimeVisible()
         {
             DbCommand command = new FireboltCommand();
-            Assert.True(command.DesignTimeVisible); // the default
+            Assert.That(command.DesignTimeVisible, Is.True); // the default
             // change the value and validate it
             command.DesignTimeVisible = false;
-            Assert.False(command.DesignTimeVisible);
+            Assert.That(command.DesignTimeVisible, Is.False);
             // restore the value and validate again
             command.DesignTimeVisible = true;
-            Assert.True(command.DesignTimeVisible);
+            Assert.That(command.DesignTimeVisible, Is.True);
         }
 
         [Test]
@@ -467,7 +467,7 @@ namespace FireboltDotNetSdk.Tests
         public void SetAndGetConnection()
         {
             DbCommand command = new FireboltCommand();
-            Assert.Null(command.Connection);
+            Assert.That(command.Connection, Is.Null);
             FireboltConnection connection = createConnection(null);
             command.Connection = connection;
             Assert.That(command.Connection, Is.SameAs(connection));

--- a/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
@@ -492,82 +492,82 @@ namespace FireboltDotNetSdk.Tests
         }
 
         [Test]
-        public void ExecuteAsyncNonQuery_ReturnsZero_SetsTokenProperty()
+        public void ExecuteServerSideAsyncNonQuery_ReturnsZero_SetsTokenProperty()
         {
             string expectedToken = "test-async-token-123";
             string response = $"{{\"token\":\"{expectedToken}\"}}";
             var connection = new FireboltConnection(mockConnectionString) { Client = new MockClient(response), EngineUrl = "engine" };
             var command = new FireboltCommand(connection, "SELECT 1", new FireboltParameterCollection());
 
-            int result = command.ExecuteAsyncNonQuery();
+            int result = command.ExecuteServerSideAsyncNonQuery();
 
             Assert.That(result, Is.EqualTo(0));
             Assert.That(command.AsyncToken, Is.EqualTo(expectedToken));
         }
 
         [Test]
-        public void ExecuteAsyncNonQuery_WithNullConnection_ThrowsException()
+        public void ExecuteServerSideAsyncNonQuery_WithNullConnection_ThrowsException()
         {
             var command = new FireboltCommand(null, "SELECT 1", new FireboltParameterCollection());
 
-            var ex = Assert.Throws<FireboltException>(() => command.ExecuteAsyncNonQuery());
+            var ex = Assert.Throws<FireboltException>(() => command.ExecuteServerSideAsyncNonQuery());
             Assert.That(ex.Message, Does.Contain("no connection was initialised"));
         }
 
 
         [Test]
-        public void ExecuteAsyncNonQuery_WithNullResponse_ThrowsException()
+        public void ExecuteServerSideAsyncNonQuery_WithNullResponse_ThrowsException()
         {
             var connection = new FireboltConnection(mockConnectionString) { Client = new MockClient(null), EngineUrl = "engine" };
             var command = new FireboltCommand(connection, "SELECT 1", new FireboltParameterCollection());
 
-            var ex = Assert.Throws<FireboltException>(() => command.ExecuteAsyncNonQuery());
+            var ex = Assert.Throws<FireboltException>(() => command.ExecuteServerSideAsyncNonQuery());
             Assert.That(ex.Message, Does.Contain("no response"));
         }
 
         [Test]
-        public void ExecuteAsyncNonQuery_WithInvalidJsonResponse_ThrowsException()
+        public void ExecuteServerSideAsyncNonQuery_WithInvalidJsonResponse_ThrowsException()
         {
             string response = "invalid json";
             var connection = new FireboltConnection(mockConnectionString) { Client = new MockClient(response), EngineUrl = "engine" };
             var command = new FireboltCommand(connection, "SELECT 1", new FireboltParameterCollection());
 
-            var ex = Assert.Throws<FireboltException>(() => command.ExecuteAsyncNonQuery());
+            var ex = Assert.Throws<FireboltException>(() => command.ExecuteServerSideAsyncNonQuery());
             Assert.That(ex.Message, Does.Contain("Failed to parse async query response"));
         }
 
         [Test]
-        public void ExecuteAsyncNonQuery_WithMissingToken_ThrowsException()
+        public void ExecuteServerSideAsyncNonQuery_WithMissingToken_ThrowsException()
         {
             string response = "{\"status\":\"running\"}"; // No token field
             var connection = new FireboltConnection(mockConnectionString) { Client = new MockClient(response), EngineUrl = "engine" };
             var command = new FireboltCommand(connection, "SELECT 1", new FireboltParameterCollection());
 
-            var ex = Assert.Throws<FireboltException>(() => command.ExecuteAsyncNonQuery());
+            var ex = Assert.Throws<FireboltException>(() => command.ExecuteServerSideAsyncNonQuery());
             Assert.That(ex.Message, Does.Contain("missing or empty token"));
         }
 
         [Test]
-        public void ExecuteAsyncNonQuery_SendsAsyncParameterToServer()
+        public void ExecuteServerSideAsyncNonQuery_SendsAsyncParameterToServer()
         {
             string response = "{\"token\":\"test-token\"}";
             var mockClient = new MockClient(response);
             var connection = new FireboltConnection(mockConnectionString) { Client = mockClient, EngineUrl = "engine" };
             var command = new FireboltCommand(connection, "SELECT 1", new FireboltParameterCollection());
 
-            command.ExecuteAsyncNonQuery();
+            command.ExecuteServerSideAsyncNonQuery();
 
             Assert.That(mockClient.Query, Is.EqualTo("SELECT 1"));
             Assert.That(mockClient.CapturedSetParamList, Contains.Item("async=true"));
         }
 
         [Test]
-        public void ExecuteAsyncNonQuery_ThrowsException_OnSetCommand()
+        public void ExecuteServerSideAsyncNonQuery_ThrowsException_OnSetCommand()
         {
             var connection = new FireboltConnection(mockConnectionString) { Client = new MockClient(null), EngineUrl = "engine" };
             var command = new FireboltCommand(connection, "SET param=1", new FireboltParameterCollection());
 
-            var ex = Assert.Throws<InvalidOperationException>(() => command.ExecuteAsyncNonQuery());
+            var ex = Assert.Throws<InvalidOperationException>(() => command.ExecuteServerSideAsyncNonQuery());
             Assert.That(ex.Message, Does.Contain("SET command"));
         }
     }

--- a/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltCommandTest.cs
@@ -560,5 +560,15 @@ namespace FireboltDotNetSdk.Tests
             Assert.That(mockClient.Query, Is.EqualTo("SELECT 1"));
             Assert.That(mockClient.CapturedSetParamList, Contains.Item("async=true"));
         }
+
+        [Test]
+        public void ExecuteAsyncNonQuery_ThrowsException_OnSetCommand()
+        {
+            var connection = new FireboltConnection(mockConnectionString) { Client = new MockClient(null), EngineUrl = "engine" };
+            var command = new FireboltCommand(connection, "SET param=1", new FireboltParameterCollection());
+
+            var ex = Assert.Throws<InvalidOperationException>(() => command.ExecuteAsyncNonQuery());
+            Assert.That(ex.Message, Does.Contain("SET command"));
+        }
     }
 }

--- a/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
@@ -572,15 +572,15 @@ namespace FireboltDotNetSdk.Tests
         [TestCase("ENDED_SUCCESSFULLY", false)]
         [TestCase("FAILED", false)]
         [TestCase("CANCELLED", false)]
-        public void IsAsyncQueryRunning_WithStatus_ReturnsExpectedResult(string status, bool expected)
+        public void IsServerSideAsyncQueryRunning_WithStatus_ReturnsExpectedResult(string status, bool expected)
         {
-            // Ensure the status in JSON matches exactly what the IsAsyncQueryRunning method expects
+            // Ensure the status in JSON matches exactly what the IsServerSideAsyncQueryRunning method expects
             string queryStatusJson = $"{{\"query\":{{\"query_id\":\"123\"}},\"meta\":[{{\"type\":\"string\",\"name\":\"status\"}},{{\"type\":\"string\",\"name\":\"query_id\"}}],\"data\":[[\"{status}\",\"456\"]]}}";
             var (connection, _, _) = SetupFireboltConnection(
                 FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
             );
 
-            bool result = connection.IsAsyncQueryRunning("test-token");
+            bool result = connection.IsServerSideAsyncQueryRunning("test-token");
 
             That(result, Is.EqualTo(expected));
         }
@@ -589,14 +589,14 @@ namespace FireboltDotNetSdk.Tests
         [TestCase("ENDED_SUCCESSFULLY", false)]
         [TestCase("FAILED", false)]
         [TestCase("CANCELLED", false)]
-        public async Task IsAsyncQueryRunningAsync_WithStatus_ReturnsExpectedResult(string status, bool expected)
+        public async Task IsServerSideAsyncQueryRunningAsync_WithStatus_ReturnsExpectedResult(string status, bool expected)
         {
             string queryStatusJson = $"{{\"query\":{{\"query_id\":\"123\"}},\"meta\":[{{\"type\":\"string\",\"name\":\"status\"}},{{\"type\":\"string\",\"name\":\"query_id\"}}],\"data\":[[\"{status}\",\"456\"]]}}";
             var (connection, _, _) = SetupFireboltConnection(
                 FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
             );
 
-            bool result = await connection.IsAsyncQueryRunningAsync("test-token");
+            bool result = await connection.IsServerSideAsyncQueryRunningAsync("test-token");
 
             That(result, Is.EqualTo(expected));
         }
@@ -605,14 +605,14 @@ namespace FireboltDotNetSdk.Tests
         [TestCase("ENDED_SUCCESSFULLY", true)]
         [TestCase("FAILED", false)]
         [TestCase("CANCELLED", false)]
-        public void IsAsyncQuerySuccessful_WithStatus_ReturnsExpectedResult(string status, bool? expected)
+        public void IsServerSideAsyncQuerySuccessful_WithStatus_ReturnsExpectedResult(string status, bool? expected)
         {
             string queryStatusJson = $"{{\"query\":{{\"query_id\":\"123\"}},\"meta\":[{{\"type\":\"string\",\"name\":\"status\"}},{{\"type\":\"string\",\"name\":\"query_id\"}}],\"data\":[[\"{status}\",\"456\"]]}}";
             var (connection, _, _) = SetupFireboltConnection(
                 FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
             );
 
-            bool? result = connection.IsAsyncQuerySuccessful("test-token");
+            bool? result = connection.IsServerSideAsyncQuerySuccessful("test-token");
 
             That(result, Is.EqualTo(expected));
         }
@@ -621,20 +621,20 @@ namespace FireboltDotNetSdk.Tests
         [TestCase("ENDED_SUCCESSFULLY", true)]
         [TestCase("FAILED", false)]
         [TestCase("CANCELLED", false)]
-        public async Task IsAsyncQuerySuccessfulAsync_WithStatus_ReturnsExpectedResult(string status, bool? expected)
+        public async Task IsServerSideAsyncQuerySuccessfulAsync_WithStatus_ReturnsExpectedResult(string status, bool? expected)
         {
             string queryStatusJson = $"{{\"query\":{{\"query_id\":\"123\"}},\"meta\":[{{\"type\":\"string\",\"name\":\"status\"}},{{\"type\":\"string\",\"name\":\"query_id\"}}],\"data\":[[\"{status}\",\"456\"]]}}";
             var (connection, _, _) = SetupFireboltConnection(
                 FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
             );
 
-            bool? result = await connection.IsAsyncQuerySuccessfulAsync("test-token");
+            bool? result = await connection.IsServerSideAsyncQuerySuccessfulAsync("test-token");
 
             That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void CancelAsyncQuery_ValidToken_ReturnsTrue()
+        public void CancelServerSideAsyncQuery_ValidToken_ReturnsTrue()
         {
             string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"RUNNING\",\"456\"]]}";
             string cancelResponseJson = "{\"query\":{\"query_id\":\"124\"},\"meta\":[],\"data\":[[]]}";
@@ -643,13 +643,13 @@ namespace FireboltDotNetSdk.Tests
                 FireboltClientTest.GetResponseMessage(cancelResponseJson, HttpStatusCode.OK)
             );
 
-            bool result = connection.CancelAsyncQuery("test-token");
+            bool result = connection.CancelServerSideAsyncQuery("test-token");
 
             That(result, Is.True);
         }
 
         [Test]
-        public async Task CancelAsyncQueryAsync_ValidToken_ReturnsTrue()
+        public async Task CancelServerSideAsyncQueryAsync_ValidToken_ReturnsTrue()
         {
             string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"RUNNING\",\"456\"]]}";
             string cancelResponseJson = "{\"query\":{\"query_id\":\"124\"},\"meta\":[],\"data\":[[]]}";
@@ -658,7 +658,7 @@ namespace FireboltDotNetSdk.Tests
                 FireboltClientTest.GetResponseMessage(cancelResponseJson, HttpStatusCode.OK)
             );
 
-            bool result = await connection.CancelAsyncQueryAsync("test-token");
+            bool result = await connection.CancelServerSideAsyncQueryAsync("test-token");
 
             That(result, Is.True);
         }
@@ -667,16 +667,16 @@ namespace FireboltDotNetSdk.Tests
         public void GetAsyncQueryStatus_EmptyToken_ThrowsArgumentNullException()
         {
             var (connection, _, _) = SetupFireboltConnection();
-            var ex = Throws<ArgumentNullException>(() => connection.IsAsyncQueryRunning(""));
+            var ex = Throws<ArgumentNullException>(() => connection.IsServerSideAsyncQueryRunning(""));
             That(ex, Is.Not.Null);
             That(ex!.ParamName, Is.EqualTo("token"));
         }
 
         [Test]
-        public void CancelAsyncQuery_EmptyToken_ThrowsArgumentNullException()
+        public void CancelServerSideAsyncQuery_EmptyToken_ThrowsArgumentNullException()
         {
             var (connection, _, _) = SetupFireboltConnection();
-            var ex = Throws<ArgumentNullException>(() => connection.CancelAsyncQuery(""));
+            var ex = Throws<ArgumentNullException>(() => connection.CancelServerSideAsyncQuery(""));
             That(ex, Is.Not.Null);
             That(ex!.ParamName, Is.EqualTo("token"));
         }

--- a/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
@@ -567,95 +567,69 @@ namespace FireboltDotNetSdk.Tests
             return (connection, httpClientMock, client);
         }
 
-        [Test]
-        public void IsAsyncQueryRunning_RunningQuery_ReturnsTrue()
+        [TestCase("RUNNING", true)]
+        [TestCase("ENDED_SUCCESSFULLY", false)]
+        [TestCase("FAILED", false)]
+        [TestCase("CANCELLED", false)]
+        public void IsAsyncQueryRunning_WithStatus_ReturnsExpectedResult(string status, bool expected)
         {
-            string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"RUNNING\",\"456\"]]}";
+            // Ensure the status in JSON matches exactly what the IsAsyncQueryRunning method expects
+            string queryStatusJson = $"{{\"query\":{{\"query_id\":\"123\"}},\"meta\":[{{\"type\":\"string\",\"name\":\"status\"}},{{\"type\":\"string\",\"name\":\"query_id\"}}],\"data\":[[\"{status}\",\"456\"]]}}";
             var (connection, _, _) = SetupFireboltConnection(
                 FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
             );
 
             bool result = connection.IsAsyncQueryRunning("test-token");
-
-            That(result, Is.True);
+            
+            That(result, Is.EqualTo(expected));
         }
 
-        [Test]
-        public void IsAsyncQueryRunning_CompletedQuery_ReturnsFalse()
+        [TestCase("RUNNING", true)]
+        [TestCase("ENDED_SUCCESSFULLY", false)]
+        [TestCase("FAILED", false)]
+        [TestCase("CANCELLED", false)]
+        public async Task IsAsyncQueryRunningAsync_WithStatus_ReturnsExpectedResult(string status, bool expected)
         {
-            string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"ENDED_SUCCESSFULLY\",\"456\"]]}";
-            var (connection, _, _) = SetupFireboltConnection(
-                FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
-            );
-
-            bool result = connection.IsAsyncQueryRunning("test-token");
-
-            That(result, Is.False);
-        }
-
-        [Test]
-        public async Task IsAsyncQueryRunningAsync_RunningQuery_ReturnsTrue()
-        {
-            string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"RUNNING\",\"456\"]]}";
+            string queryStatusJson = $"{{\"query\":{{\"query_id\":\"123\"}},\"meta\":[{{\"type\":\"string\",\"name\":\"status\"}},{{\"type\":\"string\",\"name\":\"query_id\"}}],\"data\":[[\"{status}\",\"456\"]]}}";
             var (connection, _, _) = SetupFireboltConnection(
                 FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
             );
 
             bool result = await connection.IsAsyncQueryRunningAsync("test-token");
 
-            That(result, Is.True);
+            That(result, Is.EqualTo(expected));
         }
 
-        [Test]
-        public void IsAsyncQuerySuccessful_RunningQuery_ReturnsNull()
+        [TestCase("RUNNING", null)]
+        [TestCase("ENDED_SUCCESSFULLY", true)]
+        [TestCase("FAILED", false)]
+        [TestCase("CANCELLED", false)]
+        public void IsAsyncQuerySuccessful_WithStatus_ReturnsExpectedResult(string status, bool? expected)
         {
-            string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"RUNNING\",\"456\"]]}";
+            string queryStatusJson = $"{{\"query\":{{\"query_id\":\"123\"}},\"meta\":[{{\"type\":\"string\",\"name\":\"status\"}},{{\"type\":\"string\",\"name\":\"query_id\"}}],\"data\":[[\"{status}\",\"456\"]]}}";
             var (connection, _, _) = SetupFireboltConnection(
                 FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
             );
 
             bool? result = connection.IsAsyncQuerySuccessful("test-token");
 
-            That(result, Is.Null);
+            That(result, Is.EqualTo(expected));
         }
 
-        [Test]
-        public void IsAsyncQuerySuccessful_SuccessfulQuery_ReturnsTrue()
+        [TestCase("RUNNING", null)]
+        [TestCase("ENDED_SUCCESSFULLY", true)]
+        [TestCase("FAILED", false)]
+        [TestCase("CANCELLED", false)]
+        public async Task IsAsyncQuerySuccessfulAsync_WithStatus_ReturnsExpectedResult(string status, bool? expected)
         {
-            string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"ENDED_SUCCESSFULLY\",\"456\"]]}";
-            var (connection, _, _) = SetupFireboltConnection(
-                FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
-            );
-
-            bool? result = connection.IsAsyncQuerySuccessful("test-token");
-
-            That(result, Is.True);
-        }
-
-        [Test]
-        public void IsAsyncQuerySuccessful_FailedQuery_ReturnsFalse()
-        {
-            string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"FAILED\",\"456\"]]}";
-            var (connection, _, _) = SetupFireboltConnection(
-                FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
-            );
-
-            bool? result = connection.IsAsyncQuerySuccessful("test-token");
-
-            That(result, Is.False);
-        }
-
-        [Test]
-        public async Task IsAsyncQuerySuccessfulAsync_SuccessfulQuery_ReturnsTrue()
-        {
-            string queryStatusJson = "{\"query\":{\"query_id\":\"123\"},\"meta\":[{\"type\":\"string\",\"name\":\"status\"},{\"type\":\"string\",\"name\":\"query_id\"}],\"data\":[[\"ENDED_SUCCESSFULLY\",\"456\"]]}";
+            string queryStatusJson = $"{{\"query\":{{\"query_id\":\"123\"}},\"meta\":[{{\"type\":\"string\",\"name\":\"status\"}},{{\"type\":\"string\",\"name\":\"query_id\"}}],\"data\":[[\"{status}\",\"456\"]]}}";
             var (connection, _, _) = SetupFireboltConnection(
                 FireboltClientTest.GetResponseMessage(queryStatusJson, HttpStatusCode.OK)
             );
 
             bool? result = await connection.IsAsyncQuerySuccessfulAsync("test-token");
 
-            That(result, Is.True);
+            That(result, Is.EqualTo(expected));
         }
 
         [Test]

--- a/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
@@ -60,6 +60,7 @@ namespace FireboltDotNetSdk.Tests
         {
             const string connectionString = "database=testdb.ib;clientid=testuser;clientsecret=testpwd;account=accountname";
             var cs = new MockFireboltConnection(connectionString);
+            cs.CleanupCache();
             Assert.Null(cs.AccountId); // retrieving account ID initializes the InfraVersion that is 1 by default
             Assert.That(cs.InfraVersion, Is.EqualTo(1));
             // now let's change the InfraVersion

--- a/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltConnectionTest.cs
@@ -549,7 +549,7 @@ namespace FireboltDotNetSdk.Tests
 
             FireResponse.LoginResponse loginResponse = new FireResponse.LoginResponse("access_token", "3600", "Bearer");
             FireResponse.GetSystemEngineUrlResponse systemEngineResponse = new FireResponse.GetSystemEngineUrlResponse() { engineUrl = "api.test.firebolt.io" };
-            
+
             var setupSequence = httpClientMock.SetupSequence(p => p.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(FireboltClientTest.GetResponseMessage(loginResponse, HttpStatusCode.OK)) // retrieve access token
                 .ReturnsAsync(FireboltClientTest.GetResponseMessage(systemEngineResponse, HttpStatusCode.OK)) // get system engine URL
@@ -581,7 +581,7 @@ namespace FireboltDotNetSdk.Tests
             );
 
             bool result = connection.IsAsyncQueryRunning("test-token");
-            
+
             That(result, Is.EqualTo(expected));
         }
 

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -488,9 +488,9 @@ namespace FireboltDotNetSdk.Client
         /// The token to track the query status can be accessed via the AsyncToken property.
         /// </summary>
         /// <returns>Always returns 0.</returns>
-        public int ExecuteAsyncNonQuery()
+        public int ExecuteServerSideAsyncNonQuery()
         {
-            return ExecuteAsyncNonQueryAsync().GetAwaiter().GetResult();
+            return ExecuteServerSideAsyncNonQueryAsync().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -498,7 +498,7 @@ namespace FireboltDotNetSdk.Client
         /// The token to track the query status can be accessed via the AsyncToken property.
         /// </summary>
         /// <returns>A task representing the asynchronous operation. Always returns 0.</returns>
-        public async Task<int> ExecuteAsyncNonQueryAsync(CancellationToken cancellationToken = default)
+        public async Task<int> ExecuteServerSideAsyncNonQueryAsync(CancellationToken cancellationToken = default)
         {
             // Execute the query with the async parameter
             string? response = await ExecuteCommandAsync(StrictCommandText, cancellationToken, true);

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -478,7 +478,7 @@ namespace FireboltDotNetSdk.Client
             {
                 throw new FireboltException("Unable to execute SQL as no connection was initialised. Create command using working connection");
             }
-            
+
             var engineUrl = Connection.EngineUrl;
             string newCommandText = StrictCommandText;
             if (Parameters.Any())
@@ -487,33 +487,33 @@ namespace FireboltDotNetSdk.Client
             }
 
             var database = Connection?.Database != string.Empty ? Connection?.Database : null;
-            
+
             // Use existing parameters but add async=true
             var asyncParams = new HashSet<string>(SetParamList)
             {
                 "async=true"
             };
-            
+
             // Execute the query with the async parameter
             string? response = await Connection!.Client.ExecuteQueryAsync(
                 engineUrl, database, Connection?.AccountId, newCommandText, asyncParams, cancellationToken);
-            
+
             if (response == null)
             {
                 throw new FireboltException("Failed to execute async query: no response received");
             }
-            
+
             try
             {
                 // Parse the async response which has a different format than regular queries
                 var jsonResponse = JObject.Parse(response);
                 var token = jsonResponse["token"]?.ToString();
-                
+
                 if (string.IsNullOrEmpty(token))
                 {
                     throw new FireboltException("Invalid async query response format: missing or empty token");
                 }
-                
+
                 // Store the token for later use
                 AsyncToken = token;
                 return 0;

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -478,10 +478,6 @@ namespace FireboltDotNetSdk.Client
             {
                 throw new FireboltException("Unable to execute SQL as no connection was initialised. Create command using working connection");
             }
-            if (Connection.Client == null)
-            {
-                throw new FireboltException("Client is undefined. Initialize connection properly");
-            }
             
             var engineUrl = Connection.EngineUrl;
             string newCommandText = StrictCommandText;
@@ -504,7 +500,7 @@ namespace FireboltDotNetSdk.Client
             
             if (response == null)
             {
-                throw new FireboltException("Failed to execute async query: null response received");
+                throw new FireboltException("Failed to execute async query: no response received");
             }
             
             try

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -53,7 +53,7 @@ namespace FireboltDotNetSdk.Client
         private bool _designTimeVisible = true;
         private DbParameterCollection _parameters;
 
-        public readonly HashSet<string> SetParamList;
+        public HashSet<string> SetParamList;
 
         public string? AsyncToken { get; private set; }
 

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -53,7 +53,7 @@ namespace FireboltDotNetSdk.Client
         private bool _designTimeVisible = true;
         private DbParameterCollection _parameters;
 
-        public HashSet<string> SetParamList;
+        public HashSet<string> SetParamList { get; private set; }
 
         public string? AsyncToken { get; private set; }
 

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -220,7 +220,12 @@ namespace FireboltDotNetSdk.Client
             var engineUrl = Connection!.EngineUrl;
             // If the command is a SET command, process it and return null
             // SET commands are not supported by the server-side async
-            if (!isServerAsync && commandText.Trim().ToUpper().StartsWith("SET"))
+            var isSetCommand = commandText.Trim().ToUpper().StartsWith("SET");
+            if (isSetCommand && isServerAsync)
+            {
+                throw new InvalidOperationException("SET commands are not supported by the server-side async");
+            }
+            if (isSetCommand)
             {
                 await ProcessSetCommand(commandText, cancellationToken);
                 return await Task.FromResult<string?>(null);

--- a/FireboltNETSDK/Client/FireboltCommand.cs
+++ b/FireboltNETSDK/Client/FireboltCommand.cs
@@ -458,20 +458,21 @@ namespace FireboltDotNetSdk.Client
         }
 
         /// <summary>
-        /// Executes a query asynchronously on the server-side and returns a token to track the query status.
+        /// Executes a query asynchronously on the server-side without returning results.
+        /// The token to track the query status can be accessed via the AsyncToken property.
         /// </summary>
-        /// <returns>A token that can be used to check the status of the async query.</returns>
-        public string ExecuteAsyncQuery()
+        /// <returns>Always returns 0.</returns>
+        public int ExecuteAsyncNonQuery()
         {
-            return ExecuteAsyncQueryAsync().GetAwaiter().GetResult();
+            return ExecuteAsyncNonQueryAsync().GetAwaiter().GetResult();
         }
 
         /// <summary>
-        /// Executes a query asynchronously on the server-side and returns a token to track the query status.
+        /// Executes a query asynchronously on the server-side without returning results.
+        /// The token to track the query status can be accessed via the AsyncToken property.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation instruction.</param>
-        /// <returns>A task representing the asynchronous operation with a token to track the async query status.</returns>
-        public async Task<string> ExecuteAsyncQueryAsync(CancellationToken cancellationToken = default)
+        /// <returns>A task representing the asynchronous operation. Always returns 0.</returns>
+        public async Task<int> ExecuteAsyncNonQueryAsync(CancellationToken cancellationToken = default)
         {
             if (Connection == null)
             {
@@ -519,35 +520,12 @@ namespace FireboltDotNetSdk.Client
                 
                 // Store the token for later use
                 AsyncToken = token;
-                return token;
+                return 0;
             }
             catch (JsonReaderException ex)
             {
                 throw new FireboltException("Failed to parse async query response", ex);
             }
-        }
-
-        /// <summary>
-        /// Gets the result of an async query by its token.
-        /// </summary>
-        /// <param name="token">The token of the async query.</param>
-        /// <returns>A DbDataReader that can be used to read the query results.</returns>
-        public DbDataReader GetAsyncQueryResult(string token)
-        {
-            return GetAsyncQueryResultAsync(token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Gets the result of an async query by its token asynchronously.
-        /// </summary>
-        /// <param name="token">The token of the async query.</param>
-        /// <param name="cancellationToken">The cancellation instruction.</param>
-        /// <returns>A task representing the asynchronous operation with a DbDataReader to read the query results.</returns>
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async Task<DbDataReader> GetAsyncQueryResultAsync(string token, CancellationToken cancellationToken = default)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
-        {
-            throw new NotImplementedException("Getting async query results is not implemented yet.");
         }
     }
 }

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -53,8 +53,8 @@ namespace FireboltDotNetSdk.Client
         private string _connectionString;
         private string? _serverVersion;
         private FireboltClient? _fireboltClient;
-        public readonly HashSet<string> SetParamList = new();
         private int _infraVersion = 0;
+        public HashSet<string> SetParamList { get; private set; } = new HashSet<string>();
         private static IDictionary<string, GetAccountIdByNameResponse> accountCache = new ConcurrentDictionary<string, GetAccountIdByNameResponse>();
 
         /// <summary>

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -550,9 +550,11 @@ namespace FireboltDotNetSdk.Client
             {
                 throw new ArgumentNullException(nameof(token), "Token cannot be null or empty");
             }
-
-            DbCommand command = CreateDbCommand();
-            command.CommandText = $"CALL fb_GetAsyncStatus('{token}')";
+            DbCommand command = CreateDbCommand("CALL fb_GetAsyncStatus(@token)");
+            var tokenParam = command.CreateParameter();
+            tokenParam.ParameterName = "@token";
+            tokenParam.Value = token;
+            command.Parameters.Add(tokenParam);
 
             using (DbDataReader reader = await command.ExecuteReaderAsync(cancellationToken))
             {
@@ -607,8 +609,12 @@ namespace FireboltDotNetSdk.Client
                 throw new FireboltException("Could not find query_id for the running query");
             }
 
-            var command = CreateDbCommand();
-            command.CommandText = $"CANCEL QUERY WHERE query_id = '{queryId}'";
+            DbCommand command = CreateDbCommand("CANCEL QUERY WHERE query_id = @queryId");
+            var queryIdParam = command.CreateParameter();
+            queryIdParam.ParameterName = "@queryId";
+            queryIdParam.Value = queryId;
+            command.Parameters.Add(queryIdParam);
+
 
             await command.ExecuteNonQueryAsync(cancellationToken);
 

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -479,9 +479,9 @@ namespace FireboltDotNetSdk.Client
         /// </summary>
         /// <param name="token">The token of the async query.</param>
         /// <returns>True if the query is still running, false otherwise.</returns>
-        public bool IsAsyncQueryRunning(string token)
+        public bool IsServerSideAsyncQueryRunning(string token)
         {
-            return IsAsyncQueryRunningAsync(token).GetAwaiter().GetResult();
+            return IsServerSideAsyncQueryRunningAsync(token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -490,7 +490,7 @@ namespace FireboltDotNetSdk.Client
         /// <param name="token">The token of the async query.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation with a boolean indicating if the query is still running.</returns>
-        public async Task<bool> IsAsyncQueryRunningAsync(string token, CancellationToken cancellationToken = default)
+        public async Task<bool> IsServerSideAsyncQueryRunningAsync(string token, CancellationToken cancellationToken = default)
         {
             var info = await GetAsyncQueryInfoAsync(token, cancellationToken);
             return info.TryGetValue("status", out string? status) && status == QueryStatusRunning;
@@ -501,9 +501,9 @@ namespace FireboltDotNetSdk.Client
         /// </summary>
         /// <param name="token">The token of the async query.</param>
         /// <returns>True if the query completed successfully, false if it failed, null if it's still running.</returns>
-        public bool? IsAsyncQuerySuccessful(string token)
+        public bool? IsServerSideAsyncQuerySuccessful(string token)
         {
-            return IsAsyncQuerySuccessfulAsync(token).GetAwaiter().GetResult();
+            return IsServerSideAsyncQuerySuccessfulAsync(token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace FireboltDotNetSdk.Client
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation with a boolean indicating if the query completed successfully, 
         /// or null if it's still running.</returns>
-        public async Task<bool?> IsAsyncQuerySuccessfulAsync(string token, CancellationToken cancellationToken = default)
+        public async Task<bool?> IsServerSideAsyncQuerySuccessfulAsync(string token, CancellationToken cancellationToken = default)
         {
             var info = await GetAsyncQueryInfoAsync(token, cancellationToken);
             info.TryGetValue("status", out string? status);
@@ -582,9 +582,9 @@ namespace FireboltDotNetSdk.Client
         /// </summary>
         /// <param name="token">The token of the async query.</param>
         /// <returns>True if the query was successfully stopped, false otherwise.</returns>
-        public bool CancelAsyncQuery(string token)
+        public bool CancelServerSideAsyncQuery(string token)
         {
-            return CancelAsyncQueryAsync(token).GetAwaiter().GetResult();
+            return CancelServerSideAsyncQueryAsync(token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -593,7 +593,7 @@ namespace FireboltDotNetSdk.Client
         /// <param name="token">The token of the async query.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation with a boolean indicating if the query was successfully stopped.</returns>
-        public async Task<bool> CancelAsyncQueryAsync(string token, CancellationToken cancellationToken = default)
+        public async Task<bool> CancelServerSideAsyncQueryAsync(string token, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(token))
             {

--- a/FireboltNETSDK/Client/FireboltConnection.cs
+++ b/FireboltNETSDK/Client/FireboltConnection.cs
@@ -336,7 +336,7 @@ namespace FireboltDotNetSdk.Client
             }
             catch (System.Exception)
             {
-                Close();
+                await CloseAsync();
                 throw;
             }
         }
@@ -569,7 +569,7 @@ namespace FireboltDotNetSdk.Client
                 for (int i = 0; i < reader.FieldCount; i++)
                 {
                     string fieldName = reader.GetName(i);
-                    string value = reader.IsDBNull(i) ? string.Empty : reader.GetString(i);
+                    string value = await reader.IsDBNullAsync(i, cancellationToken) ? string.Empty : reader.GetString(i);
                     result[fieldName] = value;
                 }
 

--- a/FireboltNETSDK/FireboltClient2.cs
+++ b/FireboltNETSDK/FireboltClient2.cs
@@ -29,7 +29,7 @@ using static FireboltDotNetSdk.Utils.Constant;
 namespace FireboltDotNetSdk;
 public class FireboltClient2 : FireboltClient
 {
-    private const string PROTOCOL_VERSION = "2.1";
+    private const string PROTOCOL_VERSION = "2.3";
     private ISet<string> engineStatusesRunning = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { "Running", "ENGINE_STATE_RUNNING" };
     private readonly string _account;
     private static IDictionary<string, string> systemEngineUrlCache = new ConcurrentDictionary<string, string>();

--- a/FireboltNETSDK/FireboltClient2.cs
+++ b/FireboltNETSDK/FireboltClient2.cs
@@ -167,7 +167,7 @@ public class FireboltClient2 : FireboltClient
         {
             throw new FireboltException($"Engine {engineName} not found.");
         }
-        if (reader.IsDBNull(1))
+        if (await reader.IsDBNullAsync(1))
         {
             throw new FireboltException($"Engine {engineName} is not attached to any database");
         }

--- a/README.md
+++ b/README.md
@@ -128,3 +128,54 @@ if (tzr.Read())
   Console.WriteLine(tzr.GetDateTime(0));
 }
 ```
+
+###### Server-side async query execution
+
+Firebolt supports server-side asynchronous query execution. This feature allows you to run queries in the background and fetch the results later. This is especially useful for long-running queries that you don't want to wait for or maintain a persistent connection to the server.
+
+**Execute Async Query**
+
+Executes a query asynchronously. This is useful for long-running queries like data manipulation operations that you don't want to block execution with. The result does not contain data and is used to receive an async query token. This token can be saved and reused, even with a new connection, to check on this query later.
+
+```cs
+var command = conn.CreateCommand();
+command.CommandText = "INSERT INTO large_table SELECT * FROM source_table";
+
+// Execute the query asynchronously
+command.ExecuteAsyncNonQuery();
+
+// Alternatively execute it asynchronously
+// await command.ExecuteAsyncNonQueryAsync();
+
+// Get the token for checking status later
+string token = command.AsyncToken;
+```
+
+**Check Async Query Status**
+
+Check the status of an asynchronous query to determine if it's still running or has completed.
+
+`IsAsyncQueryRunning` would return true or false if the query is running or has finished. `IsAsyncQuerySuccessful` would return true if the query has completed successfully, false if it has failed and null if the query is still running
+
+```cs
+// Check if the query is still running
+bool isRunning = conn.IsAsyncQueryRunning(token);
+// or asynchronously
+bool isRunning = await conn.IsAsyncQueryRunningAsync(token);
+
+// Check if the query completed successfully (returns null if still running)
+bool? isSuccessful = conn.IsAsyncQuerySuccessful(token);
+// or asynchronously
+bool? isSuccessful = await conn.IsAsyncQuerySuccessfulAsync(token);
+```
+
+**Cancel Async Query**
+
+Cancel a running asynchronous query if its execution is no longer needed.
+
+```cs
+// Cancel the async query
+bool cancelled = conn.CancelAsyncQuery(token);
+// or asynchronously
+bool cancelled = await conn.CancelAsyncQueryAsync(token);
+```

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Firebolt supports **server-side asynchronous query execution**, allowing queries
 Executing a query asynchronously means the database will start processing it in the background. Instead of returning data immediately, the response contains a **query token**, which can be used later (even in a new connection) to check the query status or retrieve results.
 
 ```cs
-var command = conn.CreateCommand();
+FireboltCommand command = (FireboltCommand)conn.CreateCommand();
 command.CommandText = "INSERT INTO large_table SELECT * FROM source_table";
 
 // Execute the query asynchronously on the server
@@ -164,6 +164,8 @@ You can check if the query is still running or if it has finished executing.
   - `null` if the query is still running  
 
 ```cs
+using FireboltConnection conn = new FireboltConnection(conn_string);
+conn.Open();
 // Check if the query is still running
 bool isRunning = conn.IsAsyncQueryRunning(token);
 
@@ -184,6 +186,8 @@ bool? isSuccessful = await conn.IsAsyncQuerySuccessfulAsync(token);
 If an asynchronous query is no longer needed, you can cancel it before execution completes.
 
 ```cs
+using FireboltConnection conn = new FireboltConnection(conn_string);
+conn.Open();
 // Cancel the async query
 bool cancelled = conn.CancelAsyncQuery(token);
 ```

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ FireboltCommand command = (FireboltCommand)conn.CreateCommand();
 command.CommandText = "INSERT INTO large_table SELECT * FROM source_table";
 
 // Execute the query asynchronously on the server
-command.ExecuteAsyncNonQuery();
+command.ExecuteServerSideAsyncNonQuery();
 
 // Alternatively, use .NET's async/await to avoid blocking the client thread
-await command.ExecuteAsyncNonQueryAsync();
+await command.ExecuteServerSideAsyncNonQueryAsync();
 
 // Store the async query token for later use
 string token = command.AsyncToken;
@@ -157,8 +157,8 @@ string token = command.AsyncToken;
 
 You can check if the query is still running or if it has finished executing.
 
-- `IsAsyncQueryRunning(token)` returns `true` if the query is still in progress and `false` if it has finished.
-- `IsAsyncQuerySuccessful(token)` returns:  
+- `IsServerSideAsyncQueryRunning(token)` returns `true` if the query is still in progress and `false` if it has finished.
+- `IsServerSideAsyncQuerySuccessful(token)` returns:  
   - `true` if the query completed successfully  
   - `false` if the query failed  
   - `null` if the query is still running  
@@ -167,18 +167,18 @@ You can check if the query is still running or if it has finished executing.
 using FireboltConnection conn = new FireboltConnection(conn_string);
 conn.Open();
 // Check if the query is still running
-bool isRunning = conn.IsAsyncQueryRunning(token);
+bool isRunning = conn.IsServerSideAsyncQueryRunning(token);
 
 // Check if the query completed successfully (returns null if it's still running)
-bool? isSuccessful = conn.IsAsyncQuerySuccessful(token);
+bool? isSuccessful = conn.IsServerSideAsyncQuerySuccessful(token);
 ```
 or use .NET asynchronous eqivalents
 ```cs
 // Check if the query is still running
-bool isRunning = await conn.IsAsyncQueryRunningAsync(token);
+bool isRunning = await conn.IsServerSideAsyncQueryRunningAsync(token);
 
 // Check if the query completed successfully (returns null if it's still running)
-bool? isSuccessful = await conn.IsAsyncQuerySuccessfulAsync(token);
+bool? isSuccessful = await conn.IsServerSideAsyncQuerySuccessfulAsync(token);
 ```
 
 ###### **Cancel an Asynchronous Query**
@@ -189,11 +189,11 @@ If an asynchronous query is no longer needed, you can cancel it before execution
 using FireboltConnection conn = new FireboltConnection(conn_string);
 conn.Open();
 // Cancel the async query
-bool cancelled = conn.CancelAsyncQuery(token);
+bool cancelled = conn.CancelServerSideAsyncQuery(token);
 ```
 or do so asynchronously 
 ```cs
-bool cancelled = await conn.CancelAsyncQueryAsync(token);
+bool cancelled = await conn.CancelServerSideAsyncQueryAsync(token);
 ```
 
 This approach ensures that long-running queries do not block your application while allowing you to monitor, manage, and cancel them as needed.


### PR DESCRIPTION
Allow running queries that don't keep the connection open. These queries executed by the server and can be referred to by their token.
Also adding helper methods to check if the query is running and if it succeeded.