### PR TITLE
fix: FIR-45494 Incorrect array typing in FireboltDataReader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /FireboltDotNetSdk.Tests/obj/Debug/net6.0
 /FireboltDotNetSdk.Tests/obj/Release/net6.0
 /FireboltDotNetSdk.Tests/obj
+.idea

--- a/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
@@ -23,7 +23,7 @@ namespace FireboltDotNetSdk.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(reader.HasRows, Is.EqualTo(false));
-                Assert.Throws<ArgumentOutOfRangeException>(() => reader.GetValue(0));
+                Assert.That(Assert.Throws<InvalidOperationException>(() => reader.GetValue(0))?.Message, Is.EqualTo("Read() must be called before fetching values"));
                 Assert.That(reader.Read(), Is.EqualTo(false));
 
                 Assert.That(reader.IsClosed, Is.EqualTo(false));
@@ -98,8 +98,8 @@ namespace FireboltDotNetSdk.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.Throws<FireboltException>(() => reader.GetValue(-1));
-                Assert.Throws<FireboltException>(() => reader.GetValue(2));
+                Assert.Throws<InvalidOperationException>(() => reader.GetValue(-1));
+                Assert.Throws<InvalidOperationException>(() => reader.GetValue(2));
                 Assert.That(reader.Read(), Is.EqualTo(false));
             });
         }

--- a/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
@@ -20,11 +20,14 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.That(reader.HasRows, Is.EqualTo(false));
-            Assert.Throws<ArgumentOutOfRangeException>(() => reader.GetValue(0));
-            Assert.That(reader.Read(), Is.EqualTo(false));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.HasRows, Is.EqualTo(false));
+                Assert.Throws<ArgumentOutOfRangeException>(() => reader.GetValue(0));
+                Assert.That(reader.Read(), Is.EqualTo(false));
 
-            Assert.That(reader.IsClosed, Is.EqualTo(false));
+                Assert.That(reader.IsClosed, Is.EqualTo(false));
+            });
             reader.Close();
             Assert.That(reader.IsClosed, Is.EqualTo(true));
         }
@@ -41,7 +44,7 @@ namespace FireboltDotNetSdk.Tests
 
             DbDataReader reader = new FireboltDataReader(null, result);
             IEnumerator enumerator = reader.GetEnumerator();
-            Assert.False(enumerator.MoveNext());
+            Assert.That(enumerator.MoveNext(), Is.False);
             reader.Close();
         }
 
@@ -74,26 +77,31 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.That(reader.HasRows, Is.EqualTo(true));
-            Assert.That(reader.FieldCount, Is.EqualTo(2));
-            Assert.That(reader.VisibleFieldCount, Is.EqualTo(2));
-            Assert.That(reader.Depth, Is.EqualTo(0));
-            Assert.That(reader.RecordsAffected, Is.EqualTo(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.HasRows, Is.EqualTo(true));
+                Assert.That(reader.FieldCount, Is.EqualTo(2));
+                Assert.That(reader.VisibleFieldCount, Is.EqualTo(2));
+                Assert.That(reader.Depth, Is.EqualTo(0));
+                Assert.That(reader.RecordsAffected, Is.EqualTo(0));
 
-            Assert.That(reader.Read(), Is.EqualTo(true));
-            Assert.That(reader.GetValue(0), Is.EqualTo(1));
-            Assert.That(reader.GetValue("number"), Is.EqualTo(1));
-            Assert.That(reader[0], Is.EqualTo(1));
-            Assert.That(reader["number"], Is.EqualTo(1));
+                Assert.That(reader.Read(), Is.EqualTo(true));
+                Assert.That(reader.GetValue(0), Is.EqualTo(1));
+                Assert.That(reader.GetValue("number"), Is.EqualTo(1));
+                Assert.That(reader[0], Is.EqualTo(1));
+                Assert.That(reader["number"], Is.EqualTo(1));
 
-            Assert.That(reader.GetValue(1), Is.EqualTo("one"));
-            Assert.That(reader[1], Is.EqualTo("one"));
-            Assert.That(reader[1], Is.EqualTo("one"));
-            Assert.That(reader["name"], Is.EqualTo("one"));
+                Assert.That(reader.GetValue(1), Is.EqualTo("one"));
+                Assert.That(reader[1], Is.EqualTo("one"));
+                Assert.That(reader["name"], Is.EqualTo("one"));
+            });
 
-            Assert.Throws<IndexOutOfRangeException>(() => reader.GetValue(-1));
-            Assert.Throws<IndexOutOfRangeException>(() => reader.GetValue(2));
-            Assert.That(reader.Read(), Is.EqualTo(false));
+            Assert.Multiple(() =>
+            {
+                Assert.Throws<FireboltException>(() => reader.GetValue(-1));
+                Assert.Throws<FireboltException>(() => reader.GetValue(2));
+                Assert.That(reader.Read(), Is.EqualTo(false));
+            });
         }
 
         [Test]
@@ -108,13 +116,16 @@ namespace FireboltDotNetSdk.Tests
 
             DbDataReader reader = new FireboltDataReader(null, result);
             IEnumerator enumerator = reader.GetEnumerator();
-            Assert.True(enumerator.MoveNext());
+            Assert.That(enumerator.MoveNext(), Is.True);
             object row = enumerator.Current;
-            Assert.NotNull(row);
+            Assert.That(row, Is.Not.Null);
             DbDataRecord record = (DbDataRecord)row;
-            Assert.That(record.GetInt32(0), Is.EqualTo(1));
-            Assert.That(record.GetString(1), Is.EqualTo("one"));
-            Assert.False(enumerator.MoveNext());
+            Assert.Multiple(() =>
+            {
+                Assert.That(record.GetInt32(0), Is.EqualTo(1));
+                Assert.That(record.GetString(1), Is.EqualTo("one"));
+            });
+            Assert.That(enumerator.MoveNext(), Is.False);
             reader.Close();
         }
 
@@ -122,11 +133,14 @@ namespace FireboltDotNetSdk.Tests
         public void MultipleResults()
         {
             DbDataReader reader = new FireboltDataReader(null, new QueryResult());
-            Assert.That(reader.NextResult(), Is.EqualTo(false));
-            Assert.That(reader.NextResultAsync().GetAwaiter().GetResult(), Is.EqualTo(false));
-            Assert.That(reader.NextResultAsync(CancellationToken.None).GetAwaiter().GetResult(), Is.EqualTo(false));
-            Assert.That(reader.NextResultAsync(new CancellationToken(false)).GetAwaiter().GetResult(), Is.EqualTo(false));
-            Assert.NotNull(reader.NextResultAsync(new CancellationToken(true)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.NextResult(), Is.EqualTo(false));
+                Assert.That(reader.NextResultAsync().GetAwaiter().GetResult(), Is.EqualTo(false));
+                Assert.That(reader.NextResultAsync(CancellationToken.None).GetAwaiter().GetResult(), Is.EqualTo(false));
+                Assert.That(reader.NextResultAsync(new CancellationToken(false)).GetAwaiter().GetResult(), Is.EqualTo(false));
+            });
+            Assert.That(reader.NextResultAsync(new CancellationToken(true)), Is.Not.Null);
         }
 
         [Test]
@@ -165,100 +179,105 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.That(reader.HasRows, Is.EqualTo(true));
-            Assert.That(reader.Read(), Is.EqualTo(true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.HasRows, Is.EqualTo(true));
+                Assert.That(reader.Read(), Is.EqualTo(true));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetByte(0), Is.EqualTo(byteValue));
+                Assert.That(reader.GetInt16(0), Is.EqualTo(byteValue));
+                Assert.That(reader.GetInt32(0), Is.EqualTo(byteValue));
+                Assert.That(reader.GetInt64(0), Is.EqualTo(byteValue));
+                Assert.That(reader.GetFloat(0), Is.EqualTo(byteValue));
+                Assert.That(reader.GetDouble(0), Is.EqualTo(byteValue));
+                Assert.That(reader.GetDecimal(0), Is.EqualTo(byteValue));
+                Assert.That(reader.GetBoolean(0), Is.EqualTo(true));
+                Assert.That(reader.GetChar(0), Is.EqualTo(Convert.ToChar(byteValue)));
 
-            Assert.That(reader.GetByte(0), Is.EqualTo(byteValue));
-            Assert.That(reader.GetInt16(0), Is.EqualTo(byteValue));
-            Assert.That(reader.GetInt32(0), Is.EqualTo(byteValue));
-            Assert.That(reader.GetInt64(0), Is.EqualTo(byteValue));
-            Assert.That(reader.GetFloat(0), Is.EqualTo(byteValue));
-            Assert.That(reader.GetDouble(0), Is.EqualTo(byteValue));
-            Assert.That(reader.GetDecimal(0), Is.EqualTo(byteValue));
-            Assert.That(reader.GetBoolean(0), Is.EqualTo(true));
-            Assert.That(reader.GetChar(0), Is.EqualTo(Convert.ToChar(byteValue)));
-
-            Assert.That(reader.GetByte(1), !Is.EqualTo(shortValue)); // shrunk
-            Assert.That(reader.GetInt16(1), Is.EqualTo(shortValue));
-            Assert.That(reader.GetInt32(1), Is.EqualTo(shortValue));
-            Assert.That(reader.GetInt64(1), Is.EqualTo(shortValue));
-            Assert.That(reader.GetFloat(1), Is.EqualTo(shortValue));
-            Assert.That(reader.GetDouble(1), Is.EqualTo(shortValue));
-            Assert.That(reader.GetDecimal(1), Is.EqualTo(shortValue));
-            Assert.That(reader.GetBoolean(1), Is.EqualTo(true));
-            Assert.That(reader.GetChar(1), Is.EqualTo(Convert.ToChar(shortValue)));
+                Assert.That(reader.GetByte(1), !Is.EqualTo(shortValue)); // shrunk
+                Assert.That(reader.GetInt16(1), Is.EqualTo(shortValue));
+                Assert.That(reader.GetInt32(1), Is.EqualTo(shortValue));
+                Assert.That(reader.GetInt64(1), Is.EqualTo(shortValue));
+                Assert.That(reader.GetFloat(1), Is.EqualTo(shortValue));
+                Assert.That(reader.GetDouble(1), Is.EqualTo(shortValue));
+                Assert.That(reader.GetDecimal(1), Is.EqualTo(shortValue));
+                Assert.That(reader.GetBoolean(1), Is.EqualTo(true));
+                Assert.That(reader.GetChar(1), Is.EqualTo(Convert.ToChar(shortValue)));
 
 
-            Assert.That(reader.GetByte(2), !Is.EqualTo(intValue)); // shrunk
-            Assert.That(reader.GetInt16(2), !Is.EqualTo(intValue)); // shrunk
-            Assert.That(reader.GetInt32(2), Is.EqualTo(intValue));
-            Assert.That(reader.GetInt64(2), Is.EqualTo(intValue));
-            Assert.That(reader.GetFloat(2), Is.EqualTo(intValue));
-            Assert.That(reader.GetDouble(2), Is.EqualTo(intValue));
-            Assert.That(reader.GetDecimal(2), Is.EqualTo(intValue));
-            Assert.That(reader.GetBoolean(2), Is.EqualTo(true));
-            Assert.That(reader.GetChar(2), Is.EqualTo((char)intValue));
+                Assert.That(reader.GetByte(2), !Is.EqualTo(intValue)); // shrunk
+                Assert.That(reader.GetInt16(2), !Is.EqualTo(intValue)); // shrunk
+                Assert.That(reader.GetInt32(2), Is.EqualTo(intValue));
+                Assert.That(reader.GetInt64(2), Is.EqualTo(intValue));
+                Assert.That(reader.GetFloat(2), Is.EqualTo(intValue));
+                Assert.That(reader.GetDouble(2), Is.EqualTo(intValue));
+                Assert.That(reader.GetDecimal(2), Is.EqualTo(intValue));
+                Assert.That(reader.GetBoolean(2), Is.EqualTo(true));
+                Assert.That(reader.GetChar(2), Is.EqualTo((char)intValue));
 
-            Assert.That(reader.GetByte(3), !Is.EqualTo(longValue)); // shrunk
-            Assert.That(reader.GetInt16(3), !Is.EqualTo(longValue)); // shrunk
-            Assert.That(reader.GetInt32(3), !Is.EqualTo(longValue)); // shrunk
-            Assert.That(reader.GetInt64(3), Is.EqualTo(longValue));
-            Assert.That(reader.GetFloat(3), Is.EqualTo(longValue));
-            Assert.That(reader.GetDouble(3), Is.EqualTo(longValue));
-            Assert.That(reader.GetDecimal(3), Is.EqualTo(longValue));
-            Assert.That(reader.GetBoolean(3), Is.EqualTo(true));
-            Assert.That(reader.GetChar(3), Is.EqualTo((char)longValue));
+                Assert.That(reader.GetByte(3), !Is.EqualTo(longValue)); // shrunk
+                Assert.That(reader.GetInt16(3), !Is.EqualTo(longValue)); // shrunk
+                Assert.That(reader.GetInt32(3), !Is.EqualTo(longValue)); // shrunk
+                Assert.That(reader.GetInt64(3), Is.EqualTo(longValue));
+                Assert.That(reader.GetFloat(3), Is.EqualTo(longValue));
+                Assert.That(reader.GetDouble(3), Is.EqualTo(longValue));
+                Assert.That(reader.GetDecimal(3), Is.EqualTo(longValue));
+                Assert.That(reader.GetBoolean(3), Is.EqualTo(true));
+                Assert.That(reader.GetChar(3), Is.EqualTo((char)longValue));
 
-            Assert.That(reader.GetByte(4), Is.EqualTo(2)); // shrunk
-            Assert.That(reader.GetInt16(4), Is.EqualTo(2)); // shrunk
-            Assert.That(reader.GetInt32(4), Is.EqualTo(2)); // shrunk
-            Assert.That(reader.GetInt64(4), Is.EqualTo(2)); // shrunk
-            Assert.That(reader.GetFloat(4), Is.EqualTo(floatValue));
-            Assert.True(Math.Abs(reader.GetDouble(4) - floatValue) <= 0.001);
-            Assert.True(Math.Abs((double)reader.GetDecimal(4) - floatValue) <= 0.001);
-            Assert.That(reader.GetBoolean(4), Is.EqualTo(true));
-            Assert.That(reader.GetChar(4), Is.EqualTo(Convert.ToChar((int)floatValue)));
+                Assert.That(reader.GetByte(4), Is.EqualTo(2)); // shrunk
+                Assert.That(reader.GetInt16(4), Is.EqualTo(2)); // shrunk
+                Assert.That(reader.GetInt32(4), Is.EqualTo(2)); // shrunk
+                Assert.That(reader.GetInt64(4), Is.EqualTo(2)); // shrunk
+                Assert.That(reader.GetFloat(4), Is.EqualTo(floatValue));
+                Assert.That(Math.Abs(reader.GetDouble(4) - floatValue), Is.LessThanOrEqualTo(0.001));
+                Assert.That(Math.Abs((double)reader.GetDecimal(4) - floatValue), Is.LessThanOrEqualTo(0.001));
+                Assert.That(reader.GetBoolean(4), Is.EqualTo(true));
+                Assert.That(reader.GetChar(4), Is.EqualTo(Convert.ToChar((int)floatValue)));
 
-            Assert.That(reader.GetByte(5), Is.EqualTo(3)); // shrunk
-            Assert.That(reader.GetInt16(5), Is.EqualTo(3)); // shrunk
-            Assert.That(reader.GetInt32(5), Is.EqualTo(3)); // shrunk
-            Assert.That(reader.GetInt64(5), Is.EqualTo(3));  // shrunk
-            Assert.That(reader.GetFloat(5), Is.EqualTo((float)doubleValue)); // shrunk
-            Assert.That(reader.GetDouble(5), Is.EqualTo(doubleValue));
-            Assert.That(reader.GetDecimal(5), Is.EqualTo(doubleValue));
-            Assert.That(reader.GetBoolean(5), Is.EqualTo(true));
-            Assert.That(reader.GetChar(5), Is.EqualTo(Convert.ToChar((int)doubleValue)));
+                Assert.That(reader.GetByte(5), Is.EqualTo(3)); // shrunk
+                Assert.That(reader.GetInt16(5), Is.EqualTo(3)); // shrunk
+                Assert.That(reader.GetInt32(5), Is.EqualTo(3)); // shrunk
+                Assert.That(reader.GetInt64(5), Is.EqualTo(3));  // shrunk
+                Assert.That(reader.GetFloat(5), Is.EqualTo((float)doubleValue)); // shrunk
+                Assert.That(reader.GetDouble(5), Is.EqualTo(doubleValue));
+                Assert.That(reader.GetDecimal(5), Is.EqualTo(doubleValue));
+                Assert.That(reader.GetBoolean(5), Is.EqualTo(true));
+                Assert.That(reader.GetChar(5), Is.EqualTo(Convert.ToChar((int)doubleValue)));
 
-            Assert.That(reader.GetBoolean(6), Is.EqualTo(true));
+                Assert.That(reader.GetBoolean(6), Is.EqualTo(true));
 
-            Assert.True(Math.Abs((double)reader.GetFloat(7) - e) <= 0.001);
-            Assert.That(reader.GetDouble(7), Is.EqualTo(e));
-            Assert.That(reader.GetDecimal(7), Is.EqualTo(e));
-            Assert.Throws<FormatException>(() => reader.GetBoolean(7));
+                Assert.That(Math.Abs(reader.GetFloat(7) - e), Is.LessThanOrEqualTo(0.001));
+                Assert.That(reader.GetDouble(7), Is.EqualTo(e));
+                Assert.That(reader.GetDecimal(7), Is.EqualTo(e));
+                Assert.Throws<FormatException>(() => reader.GetBoolean(7));
 
-            Assert.That(reader.GetByte(8), Is.EqualTo(byteValue));
-            Assert.That(reader.GetInt16(8), Is.EqualTo(byteValue));
-            Assert.That(reader.GetInt32(8), Is.EqualTo(byteValue));
-            Assert.That(reader.GetInt64(8), Is.EqualTo(byteValue));
-            Assert.Throws<FormatException>(() => reader.GetBoolean(8));
+                Assert.That(reader.GetByte(8), Is.EqualTo(byteValue));
+                Assert.That(reader.GetInt16(8), Is.EqualTo(byteValue));
+                Assert.That(reader.GetInt32(8), Is.EqualTo(byteValue));
+                Assert.That(reader.GetInt64(8), Is.EqualTo(byteValue));
+                Assert.Throws<FormatException>(() => reader.GetBoolean(8));
 
-            Assert.That(reader.GetBoolean(9), Is.EqualTo(true));
-            Assert.That(reader.GetChar(9), Is.EqualTo('t'));
+                Assert.That(reader.GetBoolean(9), Is.EqualTo(true));
+                Assert.That(reader.GetChar(9), Is.EqualTo('t'));
 
-            Assert.That(reader.GetBoolean(10), Is.EqualTo(false));
-            Assert.That(reader.GetChar(10), Is.EqualTo('0'));
-            Assert.That(reader.GetByte(10), Is.EqualTo(0));
-            Assert.That(reader.GetInt16(10), Is.EqualTo(0));
-            Assert.That(reader.GetInt32(10), Is.EqualTo(0));
-            Assert.That(reader.GetInt64(10), Is.EqualTo(0));
-
-            Assert.That(reader.Read(), Is.EqualTo(false));
-
-            Assert.That(reader.IsClosed, Is.EqualTo(false));
+                Assert.That(reader.GetBoolean(10), Is.EqualTo(false));
+                Assert.That(reader.GetChar(10), Is.EqualTo('0'));
+                Assert.That(reader.GetByte(10), Is.EqualTo(0));
+                Assert.That(reader.GetInt16(10), Is.EqualTo(0));
+                Assert.That(reader.GetInt32(10), Is.EqualTo(0));
+                Assert.That(reader.GetInt64(10), Is.EqualTo(0));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.Read(), Is.EqualTo(false));
+                Assert.That(reader.IsClosed, Is.EqualTo(false));
+            });
             reader.Close();
             Assert.That(reader.IsClosed, Is.EqualTo(true));
         }
-
 
         [Test]
         public void GetDateTime()
@@ -277,11 +296,13 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.That(reader.Read(), Is.EqualTo(true));
-            Assert.That(reader.GetDateTime(0), Is.EqualTo(DateTime.Parse("2022-05-10 21:01:02Z")));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.Read(), Is.EqualTo(true));
+                Assert.That(reader.GetDateTime(0), Is.EqualTo(DateTime.Parse("2022-05-10 21:01:02Z")));
+            });
             Assert.That(reader.Read(), Is.EqualTo(false));
         }
-
 
         [Test]
         public void GetGuidAndString()
@@ -302,44 +323,55 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.That(reader.Read(), Is.EqualTo(true));
-
-            Assert.That(reader.GetGuid(0), Is.EqualTo(new Guid("6B29FC40-CA47-1067-B31D-00DD010662DA")));
-            Assert.Throws<FormatException>(() => reader.GetGuid(1));
-            Assert.Throws<InvalidCastException>(() => reader.GetGuid(2));
-
-            Assert.That(reader.GetString(0), Is.EqualTo("6B29FC40-CA47-1067-B31D-00DD010662DA"));
-            Assert.That(reader.GetString(1), Is.EqualTo("not guid"));
-            Assert.That(reader.GetString(2), Is.EqualTo("123"));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.Read(), Is.EqualTo(true));
+                Assert.That(reader.GetGuid(0), Is.EqualTo(new Guid("6B29FC40-CA47-1067-B31D-00DD010662DA")));
+                Assert.Throws<FormatException>(() => reader.GetGuid(1));
+                Assert.Throws<InvalidCastException>(() => reader.GetGuid(2));
+                Assert.That(reader.GetString(0), Is.EqualTo("6B29FC40-CA47-1067-B31D-00DD010662DA"));
+                Assert.That(reader.GetString(1), Is.EqualTo("not guid"));
+                Assert.That(reader.GetString(2), Is.EqualTo("123"));
+            });
             char[] allChars = new char[3];
-            Assert.That(reader.GetChars(2, 0, allChars, 0, 3), Is.EqualTo("123".ToCharArray().Length));
-            Assert.That(allChars, Is.EqualTo("123".ToCharArray()));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetChars(2, 0, allChars, 0, 3), Is.EqualTo("123".ToCharArray().Length));
+                Assert.That(allChars, Is.EqualTo("123".ToCharArray()));
+            });
             char[] chars_0_2 = new char[2];
-            Assert.That(reader.GetChars(2, 0, chars_0_2, 0, 2), Is.EqualTo(2));
-            Assert.That(chars_0_2, Is.EqualTo("12".ToCharArray()));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetChars(2, 0, chars_0_2, 0, 2), Is.EqualTo(2));
+                Assert.That(chars_0_2, Is.EqualTo("12".ToCharArray()));
+            });
             char[] chars_1_2 = new char[2];
-            Assert.That(reader.GetChars(2, 1, chars_1_2, 0, 2), Is.EqualTo(2));
-            Assert.That(chars_1_2, Is.EqualTo("23".ToCharArray()));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetChars(2, 1, chars_1_2, 0, 2), Is.EqualTo(2));
+                Assert.That(chars_1_2, Is.EqualTo("23".ToCharArray()));
+            });
             char[] chars_1_1 = new char[1];
-            Assert.That(reader.GetChars(2, 1, chars_1_1, 0, 1), Is.EqualTo(1));
-            Assert.That(chars_1_1, Is.EqualTo("2".ToCharArray()));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetChars(2, 1, chars_1_1, 0, 1), Is.EqualTo(1));
+                Assert.That(chars_1_1, Is.EqualTo("2".ToCharArray()));
+            });
             Stream stream = reader.GetStream(1);
             StreamReader streamReader = new StreamReader(stream, Encoding.UTF8);
-            Assert.That(streamReader.ReadToEnd(), Is.EqualTo("not guid"));
-
-            Assert.That(reader.GetChars(2, 0, null, 0, 3), Is.EqualTo(0));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(streamReader.ReadToEnd(), Is.EqualTo("not guid"));
+                Assert.That(reader.GetChars(2, 0, null, 0, 3), Is.EqualTo(0));
+            });
             byte[] allBytes = new byte[8];
-            Assert.That(reader.GetBytes(1, 0, allBytes, 0, 8), Is.EqualTo(8));
-            Assert.That(allBytes, Is.EqualTo(Encoding.UTF8.GetBytes("not guid")));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetBytes(1, 0, allBytes, 0, 8), Is.EqualTo(8));
+                Assert.That(allBytes, Is.EqualTo(Encoding.UTF8.GetBytes("not guid")));
+                Assert.That(reader.GetTextReader(1).ReadToEnd(), Is.EqualTo("not guid"));
 
-            Assert.That(reader.GetTextReader(1).ReadToEnd(), Is.EqualTo("not guid"));
-
+            });
             Assert.That(reader.Read(), Is.EqualTo(false));
         }
 
@@ -363,11 +395,13 @@ namespace FireboltDotNetSdk.Tests
             Assert.That(reader.Read(), Is.EqualTo(true));
 
             byte[] allBytes = new byte[str.Length];
-            Assert.That(reader.GetBytes(0, 0, allBytes, 0, allBytes.Length), Is.EqualTo(allBytes.Length));
-            Assert.That(allBytes, Is.EqualTo(Encoding.UTF8.GetBytes(str)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetBytes(0, 0, allBytes, 0, allBytes.Length), Is.EqualTo(allBytes.Length));
+                Assert.That(allBytes, Is.EqualTo(Encoding.UTF8.GetBytes(str)));
+            });
             Assert.That(reader.Read(), Is.EqualTo(false));
         }
-
 
         [Test]
         public void GetScalarMetadata()
@@ -396,31 +430,34 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.That(reader.GetName(0), Is.EqualTo("guid"));
-            Assert.That(reader.GetName(1), Is.EqualTo("text"));
-            Assert.That(reader.GetName(2), Is.EqualTo("i"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetName(0), Is.EqualTo("guid"));
+                Assert.That(reader.GetName(1), Is.EqualTo("text"));
+                Assert.That(reader.GetName(2), Is.EqualTo("i"));
 
-            Assert.That(reader.GetOrdinal("guid"), Is.EqualTo(0));
-            Assert.That(reader.GetOrdinal("text"), Is.EqualTo(1));
-            Assert.That(reader.GetOrdinal("i"), Is.EqualTo(2));
+                Assert.That(reader.GetOrdinal("guid"), Is.EqualTo(0));
+                Assert.That(reader.GetOrdinal("text"), Is.EqualTo(1));
+                Assert.That(reader.GetOrdinal("i"), Is.EqualTo(2));
 
-            Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(string)));
-            Assert.That(reader.GetFieldType(1), Is.EqualTo(typeof(string)));
-            Assert.That(reader.GetFieldType(2), Is.EqualTo(typeof(int)));
+                Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(string)));
+                Assert.That(reader.GetFieldType(1), Is.EqualTo(typeof(string)));
+                Assert.That(reader.GetFieldType(2), Is.EqualTo(typeof(int)));
 
-            Assert.That(reader.GetFieldType(3), Is.EqualTo(typeof(decimal)));
-            Assert.That(reader.GetFieldType(4), Is.EqualTo(typeof(decimal)));
-            Assert.That(reader.GetFieldType(5), Is.EqualTo(typeof(decimal)));
-            Assert.That(reader.GetFieldType(6), Is.EqualTo(typeof(long)));
-            Assert.That(reader.GetFieldType(7), Is.EqualTo(typeof(float)));
-            Assert.That(reader.GetFieldType(8), Is.EqualTo(typeof(double)));
+                Assert.That(reader.GetFieldType(3), Is.EqualTo(typeof(decimal)));
+                Assert.That(reader.GetFieldType(4), Is.EqualTo(typeof(decimal)));
+                Assert.That(reader.GetFieldType(5), Is.EqualTo(typeof(decimal)));
+                Assert.That(reader.GetFieldType(6), Is.EqualTo(typeof(long)));
+                Assert.That(reader.GetFieldType(7), Is.EqualTo(typeof(float)));
+                Assert.That(reader.GetFieldType(8), Is.EqualTo(typeof(double)));
 
-            Assert.That(reader.GetFieldType(9), Is.EqualTo(typeof(DateTime)));
-            Assert.That(reader.GetFieldType(10), Is.EqualTo(typeof(DateTime)));
-            Assert.That(reader.GetFieldType(11), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetFieldType(9), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetFieldType(10), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetFieldType(11), Is.EqualTo(typeof(DateTime)));
 
-            Assert.That(reader.GetFieldType(12), Is.EqualTo(typeof(bool)));
-            Assert.That(reader.GetFieldType(13), Is.EqualTo(typeof(byte[])));
+                Assert.That(reader.GetFieldType(12), Is.EqualTo(typeof(bool)));
+                Assert.That(reader.GetFieldType(13), Is.EqualTo(typeof(byte[])));
+            });
         }
 
         [TestCase("array(int)", typeof(int[]))]
@@ -482,8 +519,11 @@ namespace FireboltDotNetSdk.Tests
             DbDataReader reader = new FireboltDataReader(null, result);
             Assert.That(reader.Read(), Is.EqualTo(true));
             object[] values = new object[3];
-            Assert.That(reader.GetValues(values), Is.EqualTo(3));
-            Assert.That(values, Is.EqualTo(new object[] { "6B29FC40-CA47-1067-B31D-00DD010662DA", "not guid", 123 }));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetValues(values), Is.EqualTo(3));
+                Assert.That(values, Is.EqualTo(new object[] { "6B29FC40-CA47-1067-B31D-00DD010662DA", "not guid", 123 }));
+            });
             Assert.That(reader.Read(), Is.EqualTo(false));
         }
 
@@ -509,13 +549,16 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.That(reader.Read(), Is.EqualTo(true));
-            Assert.Throws<InvalidCastException>(() => reader.GetBytes(0, 0, new byte[0], 0, 0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.Read(), Is.EqualTo(true));
+                Assert.Throws<InvalidCastException>(() => reader.GetBytes(0, 0, Array.Empty<byte>(), 0, 0));
+            });
             Assert.That(reader.Read(), Is.EqualTo(false));
         }
 
         [Test]
-        public async Task NullValue()
+        public void NullValue()
         {
             QueryResult result = new QueryResult
             {
@@ -532,10 +575,13 @@ namespace FireboltDotNetSdk.Tests
 
             DbDataReader reader = new FireboltDataReader(null, result);
             Assert.That(reader.Read(), Is.EqualTo(true));
-            Assert.That(reader.GetValue(0), Is.EqualTo(DBNull.Value));
-            Assert.That(reader.IsDBNull(0), Is.EqualTo(true));
-            Assert.That(await reader.IsDBNullAsync(0), Is.EqualTo(true));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(reader.GetValue(0), Is.EqualTo(DBNull.Value));
+                Assert.That(reader.IsDBNull(0), Is.EqualTo(true));
+                Assert.That(await reader.IsDBNullAsync(0), Is.EqualTo(true));
 
+            });
             Assert.That(reader.Read(), Is.EqualTo(false));
         }
 
@@ -611,34 +657,35 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.That(reader.Read(), Is.EqualTo(true));
-            Assert.That(reader.GetFloat(0), Is.EqualTo(float.PositiveInfinity));
-            Assert.That(reader.GetFloat(1), Is.EqualTo(float.PositiveInfinity));
-            Assert.That(reader.GetFloat(2), Is.EqualTo(float.NegativeInfinity));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.Read(), Is.EqualTo(true));
+                Assert.That(reader.GetFloat(0), Is.EqualTo(float.PositiveInfinity));
+                Assert.That(reader.GetFloat(1), Is.EqualTo(float.PositiveInfinity));
+                Assert.That(reader.GetFloat(2), Is.EqualTo(float.NegativeInfinity));
 
-            Assert.That(reader.GetDouble(0), Is.EqualTo(double.PositiveInfinity));
-            Assert.That(reader.GetDouble(1), Is.EqualTo(double.PositiveInfinity));
-            Assert.That(reader.GetDouble(2), Is.EqualTo(double.NegativeInfinity));
+                Assert.That(reader.GetDouble(0), Is.EqualTo(double.PositiveInfinity));
+                Assert.That(reader.GetDouble(1), Is.EqualTo(double.PositiveInfinity));
+                Assert.That(reader.GetDouble(2), Is.EqualTo(double.NegativeInfinity));
+            });
 
             // String representation of infinity may depnd on environment. It looks like ∞ on local environment and Infinity on github.
             string posInf = float.PositiveInfinity.ToString();
             string negInf = float.NegativeInfinity.ToString();
+            Assert.Multiple(() =>
+            {
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(0))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int16"));
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(1))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int16"));
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(2))?.Message, Is.EqualTo($"Cannot convert {negInf} to Int16"));
 
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(0))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int16"));
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(1))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int16"));
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(2))?.Message, Is.EqualTo($"Cannot convert {negInf} to Int16"));
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt32(0))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int32"));
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt32(1))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int32"));
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt32(2))?.Message, Is.EqualTo($"Cannot convert {negInf} to Int32"));
 
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(0))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int16"));
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(1))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int16"));
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt16(2))?.Message, Is.EqualTo($"Cannot convert {negInf} to Int16"));
-
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt32(0))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int32"));
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt32(1))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int32"));
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt32(2))?.Message, Is.EqualTo($"Cannot convert {negInf} to Int32"));
-
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt64(0))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int64"));
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt64(1))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int64"));
-            Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt64(2))?.Message, Is.EqualTo($"Cannot convert {negInf} to Int64"));
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt64(0))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int64"));
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt64(1))?.Message, Is.EqualTo($"Cannot convert {posInf} to Int64"));
+                Assert.That(Assert.Throws<InvalidCastException>(() => reader.GetInt64(2))?.Message, Is.EqualTo($"Cannot convert {negInf} to Int64"));
+            });
 
             Assert.That(reader.Read(), Is.EqualTo(false));
         }
@@ -666,11 +713,13 @@ namespace FireboltDotNetSdk.Tests
             DataTable dataTable = new DataTable();
             dataTable.Load(reader);
 
-            Assert.That(dataTable.Rows.Count, Is.EqualTo(1));
-            Assert.That(dataTable.Rows[0]["guid"], Is.EqualTo("6B29FC40-CA47-1067-B31D-00DD010662DA"));
-            Assert.That(dataTable.Rows[0]["text"], Is.EqualTo("not guid"));
-            Assert.That(dataTable.Rows[0]["i"], Is.EqualTo(123));
+            Assert.Multiple(() =>
+            {
+                Assert.That(dataTable.Rows, Has.Count.EqualTo(1));
+                Assert.That(dataTable.Rows[0]["guid"], Is.EqualTo("6B29FC40-CA47-1067-B31D-00DD010662DA"));
+                Assert.That(dataTable.Rows[0]["text"], Is.EqualTo("not guid"));
+                Assert.That(dataTable.Rows[0]["i"], Is.EqualTo(123));
+            });
         }
-
     }
 }

--- a/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltDataReaderTest.cs
@@ -424,10 +424,10 @@ namespace FireboltDotNetSdk.Tests
         }
 
         [TestCase("array(int)", typeof(int[]))]
-        [TestCase("array(int null)", typeof(int[]))]
-        [TestCase("array(int null) null", typeof(int[]))]
+        [TestCase("array(int null)", typeof(int?[]))]
+        [TestCase("array(int null) null", typeof(int?[]))]
         [TestCase("array(int) null", typeof(int[]))]
-        [TestCase("array(array(long null) null) null", typeof(long[][]))]
+        [TestCase("array(array(long null) null) null", typeof(long?[][]))]
         public void GetArrayMetadata(string typeDefinition, Type expectedType)
         {
             QueryResult result = new QueryResult
@@ -458,7 +458,7 @@ namespace FireboltDotNetSdk.Tests
             };
 
             DbDataReader reader = new FireboltDataReader(null, result);
-            Assert.Throws<InvalidCastException>(() => reader.GetFieldType(0));
+            Assert.Throws<FireboltException>(() => reader.GetFieldType(0));
         }
 
         [Test]

--- a/FireboltNETSDK/Client/FireboltDataReader.cs
+++ b/FireboltNETSDK/Client/FireboltDataReader.cs
@@ -32,12 +32,12 @@ namespace FireboltDotNetSdk.Client
     public sealed class FireboltDataReader : DbDataReader
     {
         private bool _closed = false;
-        private string? _fullTableName;
-        private QueryResult _queryResult;
-        private int _depth;
+        private readonly string? _fullTableName;
+        private readonly QueryResult _queryResult;
+        private readonly int _depth;
         private int _currentRowIndex = -1;
-        private const int matchTimeoutSeconds = 60;
-        private static IDictionary<string, Type> typesMap = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
+        private const int MatchTimeoutSeconds = 60;
+        private static readonly IDictionary<string, Type> TypesMap = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
         {
             { "boolean", typeof(bool) },
 
@@ -121,19 +121,19 @@ namespace FireboltDotNetSdk.Client
         public override bool GetBoolean(int ordinal)
         {
             object value = GetValue(ordinal);
-            switch (value)
+            return value switch
             {
-                case bool b: return b;
-                case float f: return (float)f != 0;
-                case double d: return (double)d != 0;
-                case decimal d: return d != 0;
-                case byte b: return b != 0;
-                case short s: return s != 0;
-                case int i: return i != 0;
-                case long l: return l != 0;
-                case string s: return TypesConverter.ParseBoolean(s);
-                default: throw new InvalidCastException($"Cannot cast ({value.GetType()}){value} to boolean");
-            }
+                bool b => b,
+                float f => Math.Abs(f) > 0.000001f,
+                double d => Math.Abs(d) > 0.000001f,
+                decimal d => d != 0,
+                byte b => b != 0,
+                short s => s != 0,
+                int i => i != 0,
+                long l => l != 0,
+                string s => TypesConverter.ParseBoolean(s),
+                _ => throw new InvalidCastException($"Cannot cast ({value.GetType()}){value} to boolean")
+            };
         }
 
         /// <inheritdoc/>
@@ -165,7 +165,7 @@ namespace FireboltDotNetSdk.Client
                 case byte[] b: bytes = b; break;
                 default: throw new InvalidCastException($"Cannot retrive byte array from ({value.GetType()}){value}");
             }
-            return GetBuffer(bytes, dataOffset, buffer, bufferOffset, length);
+            return GetBuffer(bytes, dataOffset, buffer, bufferOffset);
         }
 
         /// <inheritdoc/>
@@ -189,10 +189,10 @@ namespace FireboltDotNetSdk.Client
         /// <inheritdoc/>
         public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
         {
-            return GetBuffer(GetString(ordinal).ToCharArray(), dataOffset, buffer, bufferOffset, length);
+            return GetBuffer(GetString(ordinal).ToCharArray(), dataOffset, buffer, bufferOffset);
         }
 
-        private long GetBuffer<T>(T[] source, long dataOffset, T[]? buffer, int bufferOffset, int length)
+        private static long GetBuffer<T>(T[] source, long dataOffset, T[]? buffer, int bufferOffset)
         {
             if (buffer == null)
             {
@@ -279,15 +279,15 @@ namespace FireboltDotNetSdk.Client
                 return GetArrayTypeByName(typeName, 0);
             }
             typeName = Remove(typeName, @"\(.*");
-            return typesMap[typeName] ?? typeof(object);
+            return TypesMap[typeName] ?? typeof(object);
         }
 
-        private string Remove(string str, string regex)
+        private static string Remove(string str, string regex)
         {
-            return Regex.Replace(str, regex, "", RegexOptions.IgnoreCase, TimeSpan.FromSeconds(matchTimeoutSeconds));
+            return Regex.Replace(str, regex, "", RegexOptions.IgnoreCase, TimeSpan.FromSeconds(MatchTimeoutSeconds));
         }
 
-        private bool IsArrayType(string typeName)
+        private static bool IsArrayType(string typeName)
         {
             return typeName.ToLower().StartsWith("array");
         }
@@ -428,7 +428,7 @@ namespace FireboltDotNetSdk.Client
         /// <inheritdoc/>
         public override int GetOrdinal(string name)
         {
-            return _queryResult?.Meta.FindIndex(m => m.Name == name) ?? throw new IndexOutOfRangeException($"Cannot find index for column {name}");
+            return _queryResult?.Meta.FindIndex(m => m.Name == name) ?? throw new FireboltException($"Cannot find index for column {name}");
         }
 
         /// <inheritdoc/>
@@ -459,10 +459,6 @@ namespace FireboltDotNetSdk.Client
         public override int GetValues(object[] values)
         {
             List<object?> row = _queryResult.Data[_currentRowIndex] ?? new List<object?>();
-            if (row == null)
-            {
-                return 0;
-            }
             int n = Math.Min(row.Count, values.Length);
             for (int i = 0; i < n; i++)
             {
@@ -482,7 +478,7 @@ namespace FireboltDotNetSdk.Client
             List<object?>? row = _queryResult.Data[_currentRowIndex];
             if (ordinal < 0 || ordinal > row?.Count - 1)
             {
-                throw new IndexOutOfRangeException($"Column ${ordinal} does not exist");
+                throw new FireboltException($"Column ${ordinal} does not exist");
             }
             if (row == null)
             {

--- a/FireboltNETSDK/Client/FireboltDataReader.cs
+++ b/FireboltNETSDK/Client/FireboltDataReader.cs
@@ -268,7 +268,7 @@ namespace FireboltDotNetSdk.Client
         /// <inheritdoc/>
         public override Type GetFieldType(int ordinal)
         {
-            return GetTypeByName(GetDataTypeName(ordinal)) ?? throw new ArgumentNullException($"Cannot get type of column #{ordinal}");
+            return TypesConverter.GetType(GetColumnType(ordinal)) ?? throw new ArgumentNullException($"Cannot get type of column #{ordinal}");
         }
 
         private Type GetTypeByName(string typeName)
@@ -493,8 +493,13 @@ namespace FireboltDotNetSdk.Client
             {
                 return DBNull.Value;
             }
-            var columnType = ColumnType.Of(TypesConverter.GetFullColumnTypeName(_queryResult.Meta[ordinal]));
+            var columnType = GetColumnType(ordinal);
             return TypesConverter.ConvertToCSharpVal(value.ToString(), columnType);
+        }
+
+        private ColumnType GetColumnType(int ordinal)
+        {
+            return ColumnType.Of(TypesConverter.GetFullColumnTypeName(_queryResult.Meta[ordinal]));
         }
 
         /// <summary>

--- a/FireboltNETSDK/Client/FireboltDataReader.cs
+++ b/FireboltNETSDK/Client/FireboltDataReader.cs
@@ -475,10 +475,14 @@ namespace FireboltDotNetSdk.Client
 
         private object? GetValueSafely(int ordinal)
         {
+            if (_currentRowIndex == -1)
+            {
+                throw new InvalidOperationException("Read() must be called before fetching values");
+            }
             List<object?>? row = _queryResult.Data[_currentRowIndex];
             if (ordinal < 0 || ordinal > row?.Count - 1)
             {
-                throw new FireboltException($"Column ${ordinal} does not exist");
+                throw new InvalidOperationException($"Column ${ordinal} does not exist");
             }
             if (row == null)
             {

--- a/FireboltNETSDK/Utils/Types.cs
+++ b/FireboltNETSDK/Utils/Types.cs
@@ -25,19 +25,22 @@ namespace FireboltDoNetSdk.Utils
         //Regex that matches the string Nullable(<type>), where type is the type that we need to capture.
         private const string NullableTypePattern = @"Nullable\(([^)]+)\)";
         private const int matchTimeoutSeconds = 60;
-        internal static IDictionary<string, double> doubleInfinity = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase)
+
+        private static readonly IDictionary<string, double> DoubleInfinity = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase)
         {
             { "inf", double.PositiveInfinity },
             { "+inf", double.PositiveInfinity },
             { "-inf", double.NegativeInfinity },
         };
-        internal static IDictionary<string, float> floatInfinity = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase)
+
+        private static readonly IDictionary<string, float> FloatInfinity = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase)
         {
             { "inf", float.PositiveInfinity },
             { "+inf", float.PositiveInfinity },
             { "-inf", float.NegativeInfinity },
         };
-        internal static ISet<object> infinityValues = new HashSet<object>()
+
+        private static readonly ISet<object> InfinityValues = new HashSet<object>()
         {
             double.PositiveInfinity, double.NegativeInfinity, float.PositiveInfinity, float.NegativeInfinity
         };
@@ -184,7 +187,7 @@ namespace FireboltDoNetSdk.Utils
         {
             return val switch
             {
-                string str when doubleInfinity.ContainsKey(str) => doubleInfinity[str],
+                string str when DoubleInfinity.ContainsKey(str) => DoubleInfinity[str],
                 double d => d,
                 _ => Convert.ToDouble(val)
             };
@@ -194,7 +197,7 @@ namespace FireboltDoNetSdk.Utils
         {
             return val switch
             {
-                string str when floatInfinity.ContainsKey(str) => floatInfinity[str],
+                string str when FloatInfinity.ContainsKey(str) => FloatInfinity[str],
                 float f => f,
                 _ => Convert.ToSingle(val)
             };
@@ -284,7 +287,7 @@ namespace FireboltDoNetSdk.Utils
 
         public static bool isInfinity(object value)
         {
-            return infinityValues.Contains(value);
+            return InfinityValues.Contains(value);
         }
 
         public static bool isNaN(object value)


### PR DESCRIPTION
I changed the array casting to use the .NET Type that can be deducted from the response information, so we have less casting(no need to go into each array element to cast it to a specific type) and also we now return an array of an appropriate Type, rather than returning object[].
Also changed tests to use the expectedType since now we cast correctly for arrays.