### PR TITLE
fix: fix flaky type test

### DIFF
--- a/FireboltDotNetSdk.Tests/Integration/ServerSidePreparedStatementTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ServerSidePreparedStatementTest.cs
@@ -68,7 +68,7 @@ namespace FireboltDotNetSdk.Tests
         {
             using var connection = new FireboltConnection(USER_CONNECTION_STRING);
             connection.Open();
-            var now = DateTime.UtcNow;
+            var now = new DateTime(DateTime.UtcNow.Ticks / 10 * 10, DateTimeKind.Utc);
 
             FireboltCommand command = (FireboltCommand)connection.CreateCommand();
             command.CommandText = "SELECT $1::int, $2::long, $3::decimal(38,4), $4::real, $5::double, $6::array(int), $7::datetime, $8::text";


### PR DESCRIPTION
This fixes a issue with datetime precision between Firebolt and .NET. We now use a value rounded to microseconds (6 digits after seconds), rather that ticks(7 digits)

This is the error message:
` Error Message:
     Expected: 2025-06-04 11:26:10.4520433
  But was:  2025-06-04 11:26:10.452043`