### PR TITLE
fix: FIR-47033 fix nullable types from GetFieldType method

### DIFF
--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -481,7 +481,7 @@ namespace FireboltDotNetSdk.Tests
         }
 
         [Test]
-        [Category("general")]
+        [Category("engine-v2")]
         public void AdapterNullValuesTest()
         {
             DbDataAdapter adapter = new FireboltDataAdapter("SELECT [1,2,null]::array(int), [[1,2],[null,2],null]::array(array(int)), null::array(array(int))", USER_CONNECTION_STRING);
@@ -520,7 +520,7 @@ namespace FireboltDotNetSdk.Tests
         }
 
         [Test]
-        [Category("general")]
+        [Category("engine-v2")]
         public void AdapterVariousValuesTest()
         {
             const string query = "select  1                                                         as col_int,\n" +

--- a/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/ExecuteTest.cs
@@ -481,6 +481,101 @@ namespace FireboltDotNetSdk.Tests
         }
 
         [Test]
+        [Category("general")]
+        public void AdapterNullValuesTest()
+        {
+            DbDataAdapter adapter = new FireboltDataAdapter("SELECT [1,2,null]::array(int), [[1,2],[null,2],null]::array(array(int)), null::array(array(int))", USER_CONNECTION_STRING);
+            var dataSet = new DataSet();
+
+            adapter.Fill(dataSet);
+
+            var table = dataSet.Tables[0];
+
+            Assert.That(table.Rows, Has.Count.EqualTo(1), "Should have one row");
+
+            var row = table.Rows[0];
+            Assert.Multiple(() =>
+            {
+
+                // --- Check column types ---
+                Assert.That(table.Columns[0].DataType, Is.EqualTo(typeof(int?[])));
+                Assert.That(table.Columns[1].DataType, Is.EqualTo(typeof(int?[][])));
+                Assert.That(table.Columns[2].DataType, Is.EqualTo(typeof(int[][])));
+            });
+
+            var col0 = row.Field<int?[]>(0)!;
+            var col1 = row.Field<int?[][]>(1)!;
+            var isCol2Null = row.IsNull(2);
+
+            CollectionAssert.AreEqual(new int?[] { 1, 2, null }, col0.ToArray(), "Column 0 mismatch");
+
+            Assert.That(col1, Has.Length.EqualTo(3), "col1 outer array length mismatch");
+            CollectionAssert.AreEqual(new int?[] { 1, 2 }, col1[0], "col1[0] mismatch");
+            CollectionAssert.AreEqual(new int?[] { null, 2 }, col1[1], "col1[1] mismatch");
+            Assert.Multiple(() =>
+            {
+                Assert.That(col1[2], Is.Null, "col1[2] should be null");
+                Assert.That(isCol2Null, Is.True, "Column 2 should be NULL");
+            });
+        }
+
+        [Test]
+        [Category("general")]
+        public void AdapterVariousValuesTest()
+        {
+            const string query = "select  1                                                         as col_int,\n" +
+                                 "        null::int                                                 as col_int_null,\n" +
+                                 "        30000000000                                               as col_long,\n" +
+                                 "        null::bigint                                              as col_long_null,\n" +
+                                 "        1.23::float4                                              as col_float,\n" +
+                                 "        null::float4                                              as col_float_null,\n" +
+                                 "        1.23456789012                                             as col_double,\n" +
+                                 "        null::double                                              as col_double_null,\n" +
+                                 "        'text'                                                    as col_text,\n" +
+                                 "        null::text                                                as col_text_null,\n" +
+                                 "        '2021-03-28'::date                                        as col_date,\n" +
+                                 "        null::date                                                as col_date_null,\n" +
+                                 "        '2019-07-31 01:01:01'::timestamp                          as col_timestamp,\n" +
+                                 "        null::timestamp                                           as col_timestamp_null,\n" +
+                                 "        '1111-01-05 17:04:42.123456'::timestamptz                 as col_timestamptz,\n" +
+                                 "        null::timestamptz                                         as col_timestamptz_null,\n" +
+                                 "        true                                                      as col_boolean,\n" +
+                                 "        null::bool                                                as col_boolean_null,\n" +
+                                 "        [1,2,3,4]                                                 as col_array,\n" +
+                                 "        null::array(int)                                          as col_array_null,\n" +
+                                 "        [1,2,null]::array(int)                                    as col_array_null_int,\n" +
+                                 "        '1231232.123459999990457054844258706536'::decimal(38, 30) as col_decimal,\n" +
+                                 "        null::decimal(38, 30)                                     as col_decimal_null,\n" +
+                                 "        'abc123'::bytea                                           as col_bytea,\n" +
+                                 "        null::bytea                                               as col_bytea_null,\n" +
+                                 "        'point(1 2)'::geography                                   as col_geography,\n" +
+                                 "        null::geography                                           as col_geography_null,\n" +
+                                 "        [[1,2],[null,2],null]::array(array(int))                  as col_arr_arr,\n" +
+                                 "        null::array(array(int))                                   as col_arr_arr_null";
+            DbDataAdapter adapter = new FireboltDataAdapter(query, USER_CONNECTION_STRING);
+            var dataSet = new DataSet();
+
+            adapter.Fill(dataSet);
+            var types = new List<Type>
+            {
+                typeof(int), typeof(int), typeof(long), typeof(long),
+                typeof(float), typeof(float), typeof(double), typeof(double),
+                typeof(string), typeof(string), typeof(DateTime), typeof(DateTime),
+                typeof(DateTime), typeof(DateTime), typeof(DateTime), typeof(DateTime),
+                typeof(bool), typeof(bool), typeof(int[]), typeof(int[]), typeof(int?[]),
+                typeof(decimal), typeof(decimal), typeof(byte[]), typeof(byte[]),
+                typeof(string), typeof(string), typeof(int?[][]), typeof(int[][])
+            };
+
+            var table = dataSet.Tables[0];
+
+            for (var i = 0; i < types.Count; i++)
+            {
+                Assert.That(table.Columns[i].DataType, Is.EqualTo(types[i]));
+            }
+        }
+
+        [Test]
         [Category("v1")]
         public void ExecuteServiceAccountLoginWithInvalidCredentialsV1()
         {
@@ -716,9 +811,9 @@ namespace FireboltDotNetSdk.Tests
                 DbCommand selectAll = CreateCommand(conn, SELECT_ALL_SIMPLE);
                 Type[] expectedTypes = new Type[]
                 {
-                    typeof(int?), typeof(decimal?), typeof(long?), typeof(float?), typeof(decimal?), typeof(double?),
-                    typeof(string), typeof(DateTime?), typeof(DateTime?), typeof(DateTime?), typeof(bool?),
-                    typeof(byte?[])
+                    typeof(int), typeof(decimal), typeof(long), typeof(float), typeof(decimal), typeof(double),
+                    typeof(string), typeof(DateTime), typeof(DateTime), typeof(DateTime), typeof(bool),
+                    typeof(byte[])
                 };
 
                 using (DbDataReader reader = selectAll.ExecuteReader())

--- a/FireboltDotNetSdk.Tests/Integration/StreamingQueryTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/StreamingQueryTest.cs
@@ -40,12 +40,12 @@ namespace FireboltDotNetSdk.Tests
 
         private static readonly List<Type> TypeList = new()
         {
-            typeof(int), typeof(int?), typeof(long), typeof(long?),
-            typeof(float), typeof(float?), typeof(double), typeof(double?),
-            typeof(string), typeof(string), typeof(DateTime), typeof(DateTime?),
-            typeof(DateTime), typeof(DateTime?), typeof(DateTime), typeof(DateTime?),
-            typeof(bool), typeof(bool?), typeof(int[]), typeof(int[]), typeof(int?[]),
-            typeof(decimal), typeof(decimal?), typeof(byte[]), typeof(byte?[]),
+            typeof(int), typeof(int), typeof(long), typeof(long),
+            typeof(float), typeof(float), typeof(double), typeof(double),
+            typeof(string), typeof(string), typeof(DateTime), typeof(DateTime),
+            typeof(DateTime), typeof(DateTime), typeof(DateTime), typeof(DateTime),
+            typeof(bool), typeof(bool), typeof(int[]), typeof(int[]), typeof(int?[]),
+            typeof(decimal), typeof(decimal), typeof(byte[]), typeof(byte[]),
             typeof(string), typeof(string), typeof(int?[][]), typeof(int[][])
         };
 

--- a/FireboltNETSDK/Utils/Types.cs
+++ b/FireboltNETSDK/Utils/Types.cs
@@ -121,19 +121,13 @@ namespace FireboltDoNetSdk.Utils
                     FireboltDataType.Double => typeof(double),
                     FireboltDataType.Float => typeof(float),
                     FireboltDataType.Boolean => typeof(bool),
-                    FireboltDataType.ByteA => columnType.Nullable ? typeof(byte?[]) : typeof(byte[]),
+                    FireboltDataType.ByteA => typeof(byte[]),
                     FireboltDataType.Null => throw new FireboltException("Not null value in null type"),
                     _ => throw new FireboltException("Invalid destination type: " + columnType.Type)
                 }
             };
-            if (normalType == typeof(string)
-                || normalType == typeof(byte?[])
-                || normalType == typeof(byte[])
-                || !columnType.Nullable)
-            {
-                return normalType;
-            }
-            return typeof(Nullable<>).MakeGenericType(normalType);
+
+            return normalType;
         }
 
         public static Type GetArrayType(ArrayType arrayType)
@@ -143,7 +137,12 @@ namespace FireboltDoNetSdk.Utils
                 return GetArrayType(innerArrayType).MakeArrayType();
             }
 
-            return GetType(arrayType.InnerType).MakeArrayType();
+            var type = GetType(arrayType.InnerType);
+            if (arrayType.InnerType.Nullable)
+            {
+                type = typeof(Nullable<>).MakeGenericType(type);
+            }
+            return type.MakeArrayType();
         }
 
         public static bool ParseBoolean(object val)


### PR DESCRIPTION
When fixing array typing I introduced a bug when using DataAdapters. DataAdapters don't work with nullable types, only not null and refference types.
This PR will make it so GetFieldType will return a not null type. The only exception is when the base type of an array column is nullable, then the base array type will be nullable:
Array(Array(...(Array(Int NULL))....)) -> int?[][]....
Array(Array(...(Array(Int) NULL) NULL)....) NULL) NULL -> int[][]....