### PR TITLE
feat: FIR-48856 add implicit struct deserialization to custom objects with mapping

### DIFF
--- a/FireboltDotNetSdk.Tests/Integration/DataTypesTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/DataTypesTest.cs
@@ -2,7 +2,10 @@ using System.Data;
 using System.Data.Common;
 using System.Text;
 using FireboltDotNetSdk.Client;
+using FireboltDotNetSdk.Utils;
 using static System.DateTime;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace FireboltDotNetSdk.Tests
 {
@@ -69,7 +72,7 @@ namespace FireboltDotNetSdk.Tests
                 "        ['2019-07-31 01:01:01',null]::array(timestamp)                                   as col_timestamp_null_array,\n" +
                 "        null::array(timestamp)                                                           as col_timestamp_array_null,\n" +
                 "        [['2019-07-31 01:01:01','2019-08-01 00:00:00'],null]::array(array(timestamp))    as col_timestamp_array_null_array,\n" +
-                "        [['2019-07-31 01:01:01','2019-08-01 00:00:00'],[]]::array(array(timestamp))      as col_timestamp_array_null_array,\n" +
+                "        [['2019-07-31 01:01:01','2019-08-01 00:00:00'],[]]::array(array(timestamp))      as col_timestamp_array_array,\n" +
                 "        [['2019-07-31 01:01:01',null],null]::array(array(timestamp))                     as col_timestamp_null_array_null_array,\n" +
                 "        null::array(array(timestamp))                                                    as col_timestamp_array_array_null,\n" +
                 "        '1111-01-05 17:04:42.123456+00'::timestamptz                                                           as col_timestamptz,\n" +
@@ -78,7 +81,7 @@ namespace FireboltDotNetSdk.Tests
                 "        ['1111-01-05 17:04:42.123456+00',null]::array(timestamptz)                                             as col_timestamptz_null_array,\n" +
                 "        null::array(timestamptz)                                                                               as col_timestamptz_array_null,\n" +
                 "        [['1111-01-05 17:04:42.123456+00','1111-01-06 17:04:42.123456+00'],null]::array(array(timestamptz))    as col_timestamptz_array_null_array,\n" +
-                "        [['1111-01-05 17:04:42.123456+00','1111-01-06 17:04:42.123456+00'],[]]::array(array(timestamptz))      as col_timestamptz_array_null_array,\n" +
+                "        [['1111-01-05 17:04:42.123456+00','1111-01-06 17:04:42.123456+00'],[]]::array(array(timestamptz))      as col_timestamptz_array_array,\n" +
                 "        [['1111-01-05 17:04:42.123456+00',null],null]::array(array(timestamptz))                               as col_timestamptz_null_array_null_array,\n" +
                 "        null::array(array(timestamptz))                                                                        as col_timestamptz_array_array_null,\n" +
                 "        true                                    as col_boolean,\n" +
@@ -95,7 +98,7 @@ namespace FireboltDotNetSdk.Tests
                 "        ['1.50',null]::array(decimal(38, 30))                        as col_decimal_null_array,\n" +
                 "        null::array(decimal(38, 30))                                 as col_decimal_array_null,\n" +
                 "        [['1.50','-2.25'],null]::array(array(decimal(38, 30)))       as col_decimal_array_null_array,\n" +
-                "        [['1.50','-2.25'],[]]::array(array(decimal(38, 30)))         as col_decimal_array_null_array,\n" +
+                "        [['1.50','-2.25'],[]]::array(array(decimal(38, 30)))         as col_decimal_array_array,\n" +
                 "        [['1.50',null],null]::array(array(decimal(38, 30)))          as col_decimal_null_array_null_array,\n" +
                 "        null::array(array(decimal(38, 30)))                          as col_decimal_array_array_null,\n" +
                 "        'abc123'::bytea                                    as col_bytea,\n" +
@@ -331,6 +334,199 @@ namespace FireboltDotNetSdk.Tests
             VerifyReturnedValues(reader);
         }
 
+        [Test]
+        [Category("engine-v2")]
+        public void ExecuteReader_GetFieldValue_Generic_CorrectTypes()
+        {
+            using var connection = new FireboltConnection(UserConnectionString);
+            connection.Open();
+            var command = (FireboltCommand)connection.CreateCommand();
+            command.CommandText = VariousTypeQuery;
+
+            using var reader = command.ExecuteReader();
+            Assert.That(reader.Read(), Is.True);
+
+            var getFieldValueGeneric = reader.GetType().GetMethod(nameof(FireboltDataReader.GetFieldValue))!;
+
+            for (var i = 0; i < TypeList.Count; i++)
+            {
+                if (ExpectedValues[i] is null)
+                {
+                    Assert.That(reader.IsDBNull(i), Is.True, $"Column {i} should be NULL");
+                    Assert.Throws<InvalidCastException>(() => reader.GetFieldValue<object>(i));
+                }
+                else
+                {
+                    var method = getFieldValueGeneric.MakeGenericMethod(TypeList[i]);
+                    var value = method.Invoke(reader, new object[] { i });
+                    Assert.That(value, Is.EqualTo(ExpectedValues[i]), $"Generic GetFieldValue mismatch at column {i}");
+                }
+            }
+        }
+
+        [Test]
+        [Category("engine-v2")]
+        public void ExecuteReader_GetFieldValue_Generic_WrongTypes()
+        {
+            using var connection = new FireboltConnection(UserConnectionString);
+            connection.Open();
+            var command = (FireboltCommand)connection.CreateCommand();
+            command.CommandText = VariousTypeQuery;
+
+            using var reader = command.ExecuteReader();
+            Assert.That(reader.Read(), Is.True);
+
+            for (var i = 0; i < TypeList.Count; i++)
+            {
+                var ex = Assert.Throws<InvalidCastException>(() => reader.GetFieldValue<TimeSpan>(i));
+                Assert.That(ex.Message,
+                    ExpectedValues[i] is null
+                        ? Does.Contain("is null (DBNull) and cannot be cast to TimeSpan")
+                        : Does.Not.Contain("DBNull"));
+            }
+        }
+
+        [Test]
+        [Category("engine-v2")]
+        public void CreateSelect_Struct_With_All_VariousTypes()
+        {
+            using var connection = new FireboltConnection(UserConnectionString);
+            connection.Open();
+
+            var setup = new[]
+            {
+                "SET advanced_mode=1",
+                "SET enable_create_table_v2=true",
+                "SET enable_struct_syntax=true",
+                "SET prevent_create_on_information_schema=true",
+                "SET enable_create_table_with_struct_type=true",
+                "DROP TABLE IF EXISTS struct_various_types_helper",
+                "DROP TABLE IF EXISTS struct_various"
+            };
+            foreach (var s in setup)
+            {
+                var c = (FireboltCommand)connection.CreateCommand();
+                c.CommandText = s;
+                c.ExecuteNonQuery();
+            }
+
+            // Create helper table with all columns from VariousTypeQuery
+            var createHelper = (FireboltCommand)connection.CreateCommand();
+            createHelper.CommandText = $"CREATE TABLE struct_various_types_helper AS {VariousTypeQuery}";
+            createHelper.ExecuteNonQuery();
+
+            // Extract column aliases from VariousTypeQuery in order
+            var aliases = Regex.Matches(VariousTypeQuery, @"as\s+([a-zA-Z_]*)")
+                .Select(m => m.Groups[1].Value)
+                .ToList();
+
+            // Read column types from information_schema to build struct(name type, ...)
+            var typesCmd = (FireboltCommand)connection.CreateCommand();
+            typesCmd.CommandText = "SELECT column_name, data_type FROM information_schema.columns WHERE table_name='struct_various_types_helper' ORDER BY ordinal_position";
+            var typeMap = new Dictionary<string, string>();
+            using (var tReader = typesCmd.ExecuteReader())
+            {
+                while (tReader.Read())
+                {
+                    var col = tReader.GetString(0);
+                    var typ = tReader.GetString(1);
+                    typeMap[col] = typ;
+                }
+            }
+
+            var structTypeDef = string.Join(", ", aliases.Select(a => $"{a} {typeMap[a]}"));
+
+            // Create table with explicit struct schema
+            var createStruct = (FireboltCommand)connection.CreateCommand();
+            createStruct.CommandText = $"CREATE TABLE struct_various (s struct({structTypeDef}))";
+            createStruct.ExecuteNonQuery();
+
+            // Insert rows by packing helper columns into the struct
+            var structExpr = string.Join(", ", aliases);
+            var insertStruct = (FireboltCommand)connection.CreateCommand();
+            insertStruct.CommandText = $"INSERT INTO struct_various SELECT struct({structExpr}) FROM struct_various_types_helper";
+            insertStruct.ExecuteNonQuery();
+
+            // Validate: read the struct and compare every field to ExpectedValues
+            var select = (FireboltCommand)connection.CreateCommand();
+            select.CommandText = "SELECT s FROM struct_various";
+            using var reader = select.ExecuteReader();
+            Assert.That(reader.Read(), Is.True);
+
+            var standardDic = (Dictionary<string, object?>)reader.GetValue(0);
+            var genericDic = reader.GetFieldValue<Dictionary<string, object?>>(0);
+            Assert.Multiple(() =>
+            {
+                Assert.That(standardDic, Is.Not.Null);
+                Assert.That(standardDic.Keys, Has.Count.EqualTo(aliases.Count));
+                Assert.That(genericDic, Is.Not.Null);
+                Assert.That(genericDic.Keys, Has.Count.EqualTo(aliases.Count));
+            });
+
+            for (var i = 0; i < aliases.Count; i++)
+            {
+                var key = aliases[i];
+                var expected = ExpectedValues[i];
+                Assert.Multiple(() =>
+                {
+                    Assert.That(standardDic.ContainsKey(key), Is.True, $"Missing key '{key}' in struct");
+                    Assert.That(genericDic.ContainsKey(key), Is.True, $"Missing key '{key}' in struct");
+                });
+                var standardActual = standardDic[key];
+                var genericActual = genericDic[key];
+                if (expected is null)
+                {
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(standardActual, Is.Null, $"Field '{key}' expected null");
+                        Assert.That(genericActual, Is.Null, $"Field '{key}' expected null");
+                    });
+                }
+                else
+                {
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(standardActual, Is.EqualTo(expected), $"Mismatch at '{key}'");
+                        Assert.That(genericActual, Is.EqualTo(expected), $"Mismatch at '{key}'");
+                    });
+                }
+            }
+
+            // Also deserialize into POCO using FireboltStructNameAttribute and validate
+            var poco = reader.GetFieldValue<VariousStructPoco>(0);
+            var propByAlias = typeof(VariousStructPoco)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .ToDictionary(
+                    f => f.GetCustomAttribute<FireboltStructNameAttribute>(true)!.Name,
+                    f => f
+                );
+
+            for (var i = 0; i < aliases.Count; i++)
+            {
+                var alias = aliases[i];
+                var expected = ExpectedValues[i];
+                var value = propByAlias[alias].GetValue(poco);
+
+                if (expected is null)
+                {
+                    Assert.That(value, Is.Null, $"POCO field '{alias}' expected null");
+                }
+                else
+                {
+                    Assert.That(value, Is.EqualTo(expected), $"POCO mismatch at '{alias}'");
+                }
+            }
+
+            // Cleanup
+            var cleanup = new[] { "DROP TABLE struct_various", "DROP TABLE struct_various_types_helper" };
+            foreach (var s in cleanup)
+            {
+                var c = (FireboltCommand)connection.CreateCommand();
+                c.CommandText = s;
+                c.ExecuteNonQuery();
+            }
+        }
+
         private static void VerifyReturnedValues(DbDataReader reader)
         {
             for (var i = 0; i < ExpectedValues.Length; i++)
@@ -345,6 +541,127 @@ namespace FireboltDotNetSdk.Tests
                     Assert.That(value, Is.EqualTo(ExpectedValues[i]), $"Mismatch at column index {i}");
                 }
             }
+        }
+
+        private class VariousStructPoco
+        {
+            // int group
+            [FireboltStructName("col_int")] public int ColInt { get; init; }
+            [FireboltStructName("col_int_null")] public int? ColIntNull { get; init; }
+            [FireboltStructName("col_int_array")] public int[]? ColIntArray { get; init; }
+            [FireboltStructName("col_int_null_array")] public int?[]? ColIntNullArray { get; init; }
+            [FireboltStructName("col_int_array_null")] public int[]? ColIntArrayNull { get; init; }
+            [FireboltStructName("col_int_array_null_array")] public int[][]? ColIntArrayNullArray { get; init; }
+            [FireboltStructName("col_int_null_array_null_array")] public int?[][]? ColIntNullArrayNullArray { get; init; }
+            [FireboltStructName("col_int_array_array_null")] public int[][]? ColIntArrayArrayNull { get; init; }
+
+            // long group
+            [FireboltStructName("col_long")] public long ColLong { get; init; }
+            [FireboltStructName("col_long_null")] public long? ColLongNull { get; init; }
+            [FireboltStructName("col_long_array")] public long[]? ColLongArray { get; init; }
+            [FireboltStructName("col_long_null_array")] public long?[]? ColLongNullArray { get; init; }
+            [FireboltStructName("col_long_array_null")] public long[]? ColLongArrayNull { get; init; }
+            [FireboltStructName("col_long_array_null_array")] public long[][]? ColLongArrayNullArray { get; init; }
+            [FireboltStructName("col_long_null_array_null_array")] public long?[][]? ColLongNullArrayNullArray { get; init; }
+            [FireboltStructName("col_long_array_array_null")] public long[][]? ColLongArrayArrayNull { get; init; }
+
+            // float group
+            [FireboltStructName("col_float")] public float ColFloat { get; init; }
+            [FireboltStructName("col_float_null")] public float? ColFloatNull { get; init; }
+            [FireboltStructName("col_float_array")] public float[]? ColFloatArray { get; init; }
+            [FireboltStructName("col_float_null_array")] public float?[]? ColFloatNullArray { get; init; }
+            [FireboltStructName("col_float_array_null")] public float[]? ColFloatArrayNull { get; init; }
+            [FireboltStructName("col_float_array_null_array")] public float[][]? ColFloatArrayNullArray { get; init; }
+            [FireboltStructName("col_float_null_array_null_array")] public float?[][]? ColFloatNullArrayNullArray { get; init; }
+            [FireboltStructName("col_float_array_array_null")] public float[][]? ColFloatArrayArrayNull { get; init; }
+
+            // double group
+            [FireboltStructName("col_double")] public double ColDouble { get; init; }
+            [FireboltStructName("col_double_null")] public double? ColDoubleNull { get; init; }
+            [FireboltStructName("col_double_array")] public double[]? ColDoubleArray { get; init; }
+            [FireboltStructName("col_double_null_array")] public double?[]? ColDoubleNullArray { get; init; }
+            [FireboltStructName("col_double_array_null")] public double[]? ColDoubleArrayNull { get; init; }
+            [FireboltStructName("col_double_array_null_array")] public double[][]? ColDoubleArrayNullArray { get; init; }
+            [FireboltStructName("col_double_null_array_null_array")] public double?[][]? ColDoubleNullArrayNullArray { get; init; }
+            [FireboltStructName("col_double_array_array_null")] public double[][]? ColDoubleArrayArrayNull { get; init; }
+
+            // text group
+            [FireboltStructName("col_text")] public string? ColText { get; init; }
+            [FireboltStructName("col_text_null")] public string? ColTextNull { get; init; }
+            [FireboltStructName("col_text_array")] public string[]? ColTextArray { get; init; }
+            [FireboltStructName("col_text_null_array")] public string?[]? ColTextNullArray { get; init; }
+            [FireboltStructName("col_text_array_null")] public string[]? ColTextArrayNull { get; init; }
+            [FireboltStructName("col_text_array_null_array")] public string[][]? ColTextArrayNullArray { get; init; }
+            [FireboltStructName("col_text_null_array_null_array")] public string?[][]? ColTextNullArrayNullArray { get; init; }
+            [FireboltStructName("col_text_array_array_null")] public string[][]? ColTextArrayArrayNull { get; init; }
+
+            // date group
+            [FireboltStructName("col_date")] public DateTime ColDate { get; init; }
+            [FireboltStructName("col_date_null")] public DateTime? ColDateNull { get; init; }
+            [FireboltStructName("col_date_array")] public DateTime[]? ColDateArray { get; init; }
+            [FireboltStructName("col_date_null_array")] public DateTime?[]? ColDateNullArray { get; init; }
+            [FireboltStructName("col_date_array_null")] public DateTime[]? ColDateArrayNull { get; init; }
+            [FireboltStructName("col_date_array_null_array")] public DateTime?[][]? ColDateArrayNullArray { get; init; }
+            [FireboltStructName("col_date_array_array")] public DateTime[][]? ColDateArrayArray { get; init; }
+            [FireboltStructName("col_date_null_array_null_array")] public DateTime?[][]? ColDateNullArrayNullArray { get; init; }
+            [FireboltStructName("col_date_array_array_null")] public DateTime[][]? ColDateArrayArrayNull { get; init; }
+
+            // timestamp group
+            [FireboltStructName("col_timestamp")] public DateTime ColTimestamp { get; init; }
+            [FireboltStructName("col_timestamp_null")] public DateTime? ColTimestampNull { get; init; }
+            [FireboltStructName("col_timestamp_array")] public DateTime[]? ColTimestampArray { get; init; }
+            [FireboltStructName("col_timestamp_null_array")] public DateTime?[]? ColTimestampNullArray { get; init; }
+            [FireboltStructName("col_timestamp_array_null")] public DateTime[]? ColTimestampArrayNull { get; init; }
+            [FireboltStructName("col_timestamp_array_null_array")] public DateTime?[][]? ColTimestampArrayNullArray { get; init; }
+            [FireboltStructName("col_timestamp_array_array")] public DateTime[][]? ColTimestampArrayArray { get; init; }
+            [FireboltStructName("col_timestamp_null_array_null_array")] public DateTime?[][]? ColTimestampNullArrayNullArray { get; init; }
+            [FireboltStructName("col_timestamp_array_array_null")] public DateTime[][]? ColTimestampArrayArrayNull { get; init; }
+
+            // timestamptz group
+            [FireboltStructName("col_timestamptz")] public DateTime ColTimestamptz { get; init; }
+            [FireboltStructName("col_timestamptz_null")] public DateTime? ColTimestamptzNull { get; init; }
+            [FireboltStructName("col_timestamptz_array")] public DateTime[]? ColTimestamptzArray { get; init; }
+            [FireboltStructName("col_timestamptz_null_array")] public DateTime?[]? ColTimestamptzNullArray { get; init; }
+            [FireboltStructName("col_timestamptz_array_null")] public DateTime[]? ColTimestamptzArrayNull { get; init; }
+            [FireboltStructName("col_timestamptz_array_null_array")] public DateTime?[][]? ColTimestamptzArrayNullArray { get; init; }
+            [FireboltStructName("col_timestamptz_array_array")] public DateTime[][]? ColTimestamptzArrayArray { get; init; }
+            [FireboltStructName("col_timestamptz_null_array_null_array")] public DateTime?[][]? ColTimestamptzNullArrayNullArray { get; init; }
+            [FireboltStructName("col_timestamptz_array_array_null")] public DateTime[][]? ColTimestamptzArrayArrayNull { get; init; }
+
+            // boolean group
+            [FireboltStructName("col_boolean")] public bool ColBoolean { get; init; }
+            [FireboltStructName("col_boolean_null")] public bool? ColBooleanNull { get; init; }
+            [FireboltStructName("col_boolean_array")] public bool[]? ColBooleanArray { get; init; }
+            [FireboltStructName("col_boolean_null_array")] public bool?[]? ColBooleanNullArray { get; init; }
+            [FireboltStructName("col_boolean_array_null")] public bool[]? ColBooleanArrayNull { get; init; }
+            [FireboltStructName("col_boolean_array_null_array")] public bool[][]? ColBooleanArrayNullArray { get; init; }
+            [FireboltStructName("col_boolean_null_array_null_array")] public bool?[][]? ColBooleanNullArrayNullArray { get; init; }
+            [FireboltStructName("col_boolean_array_array_null")] public bool[][]? ColBooleanArrayArrayNull { get; init; }
+
+            // decimal group
+            [FireboltStructName("col_decimal")] public decimal ColDecimal { get; init; }
+            [FireboltStructName("col_decimal_null")] public decimal? ColDecimalNull { get; init; }
+            [FireboltStructName("col_decimal_array")] public decimal[]? ColDecimalArray { get; init; }
+            [FireboltStructName("col_decimal_null_array")] public decimal?[]? ColDecimalNullArray { get; init; }
+            [FireboltStructName("col_decimal_array_null")] public decimal[]? ColDecimalArrayNull { get; init; }
+            [FireboltStructName("col_decimal_array_null_array")] public decimal?[][]? ColDecimalArrayNullArray { get; init; }
+            [FireboltStructName("col_decimal_array_array")] public decimal[][]? ColDecimalArrayArray { get; init; }
+            [FireboltStructName("col_decimal_null_array_null_array")] public decimal?[][]? ColDecimalNullArrayNullArray { get; init; }
+            [FireboltStructName("col_decimal_array_array_null")] public decimal[][]? ColDecimalArrayArrayNull { get; init; }
+
+            // bytea group
+            [FireboltStructName("col_bytea")] public byte[]? ColBytea { get; init; }
+            [FireboltStructName("col_bytea_null")] public byte[]? ColByteaNull { get; init; }
+
+            // geography group
+            [FireboltStructName("col_geography")] public string? ColGeography { get; init; }
+            [FireboltStructName("col_geography_null")] public string? ColGeographyNull { get; init; }
+            [FireboltStructName("col_geography_array")] public string[]? ColGeographyArray { get; init; }
+            [FireboltStructName("col_geography_null_array")] public string?[]? ColGeographyNullArray { get; init; }
+            [FireboltStructName("col_geography_array_null")] public string[]? ColGeographyArrayNull { get; init; }
+            [FireboltStructName("col_geography_array_null_array")] public string[][]? ColGeographyArrayNullArray { get; init; }
+            [FireboltStructName("col_geography_null_array_null_array")] public string?[][]? ColGeographyNullArrayNullArray { get; init; }
+            [FireboltStructName("col_geography_array_array_null")] public string[][]? ColGeographyArrayArrayNull { get; init; }
         }
     }
 }

--- a/FireboltDotNetSdk.Tests/Integration/StructMappingTest.cs
+++ b/FireboltDotNetSdk.Tests/Integration/StructMappingTest.cs
@@ -1,0 +1,188 @@
+using System.Data.Common;
+using FireboltDotNetSdk.Client;
+using FireboltDotNetSdk.Utils;
+
+namespace FireboltDotNetSdk.Tests
+{
+    [TestFixture]
+    [Category("v2")]
+    [Category("engine-v2")]
+    internal class StructMappingTest : IntegrationTest
+    {
+        private const string TableName = "struct_test";
+
+        private static readonly string[] SetupSql =
+        {
+            "SET advanced_mode=1",
+            "SET enable_create_table_v2=true",
+            "SET enable_struct_syntax=true",
+            "SET prevent_create_on_information_schema=true",
+            "SET enable_create_table_with_struct_type=true",
+            $"DROP TABLE IF EXISTS {TableName}",
+            $"CREATE TABLE IF NOT EXISTS {TableName} (" +
+            "id numeric(5,0), " +
+            "plain struct(int_val int, str_val text, arr_val array(numeric(5,3)))" +
+            ")"
+        };
+
+        private const string CleanupSql = $"DROP TABLE IF EXISTS {TableName}";
+
+        [OneTimeSetUp]
+        public void GlobalSetup()
+        {
+            using var conn = new FireboltConnection(ConnectionString());
+            conn.Open();
+            SetupStructTable(conn);
+        }
+
+        [OneTimeTearDown]
+        public void GlobalTearDown()
+        {
+            using var conn = new FireboltConnection(ConnectionString());
+            conn.Open();
+            CreateCommand(conn, CleanupSql).ExecuteNonQuery();
+        }
+
+        [Test]
+        public void InsertAndSelectStruct_PocoWithAttributesMapping_Sync()
+        {
+            using var conn = new FireboltConnection(ConnectionString());
+            conn.Open();
+
+            var select = CreateCommand(conn, $"SELECT id, plain FROM {TableName} ORDER BY id ASC");
+            using var reader = select.ExecuteReader();
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.Read(), Is.True);
+                Assert.That(reader.GetFieldValue<decimal>(0), Is.EqualTo(1));
+            });
+            var plain = reader.GetFieldValue<PlainStructWithAttributes>(1);
+            AssertPocoWithAttributes(plain);
+            Assert.That(reader.Read(), Is.False);
+        }
+
+        [Test]
+        public async Task InsertAndSelectStruct_PocoWithAttributesMapping_Async()
+        {
+            await using var conn = new FireboltConnection(ConnectionString());
+            await conn.OpenAsync();
+
+            var select = CreateCommand(conn, $"SELECT id, plain FROM {TableName} ORDER BY id ASC");
+            await using var reader = await select.ExecuteReaderAsync();
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await reader.ReadAsync(), Is.True);
+                Assert.That(await reader.GetFieldValueAsync<decimal>(0), Is.EqualTo(1));
+            });
+            var plain = await reader.GetFieldValueAsync<PlainStructWithAttributes>(1);
+            AssertPocoWithAttributes(plain);
+            Assert.That(await reader.ReadAsync(), Is.False);
+        }
+
+        [Test]
+        public void InsertAndSelectStruct_PocoWithoutAttributesMapping_Sync()
+        {
+            using var conn = new FireboltConnection(ConnectionString());
+            conn.Open();
+
+            var select = CreateCommand(conn, $"SELECT id, plain FROM {TableName} ORDER BY id ASC");
+            using var reader = select.ExecuteReader();
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.Read(), Is.True);
+                Assert.That(reader.GetFieldValue<decimal>(0), Is.EqualTo(1));
+            });
+            var plain = reader.GetFieldValue<PlainStructWithoutAttributes>(1);
+            AssertPocoWithoutAttributes(plain);
+            Assert.That(reader.Read(), Is.False);
+        }
+
+        [Test]
+        public async Task InsertAndSelectStruct_PocoWithoutAttributesMapping_Async()
+        {
+            await using var conn = new FireboltConnection(ConnectionString());
+            await conn.OpenAsync();
+
+            var select = CreateCommand(conn, $"SELECT id, plain FROM {TableName} ORDER BY id ASC");
+            await using var reader = await select.ExecuteReaderAsync();
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await reader.ReadAsync(), Is.True);
+                Assert.That(await reader.GetFieldValueAsync<decimal>(0), Is.EqualTo(1));
+            });
+            var plain = await reader.GetFieldValueAsync<PlainStructWithoutAttributes>(1);
+            AssertPocoWithoutAttributes(plain);
+            Assert.That(await reader.ReadAsync(), Is.False);
+        }
+
+        private static void AssertPocoWithAttributes(PlainStructWithAttributes plain)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(plain.IntVal, Is.EqualTo(1));
+                Assert.That(plain.StrVal, Is.EqualTo("test"));
+                Assert.That(plain.ArrVal, Is.Not.Null);
+                Assert.That(plain.ArrVal, Has.Length.EqualTo(2));
+                Assert.That(plain.ArrVal[0], Is.EqualTo(12.34f).Within(1e-4));
+                Assert.That(plain.ArrVal[1], Is.EqualTo(56.789f).Within(1e-4));
+            });
+        }
+
+        private static void AssertPocoWithoutAttributes(PlainStructWithoutAttributes plain)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(plain.IntVal, Is.EqualTo(1));
+                Assert.That(plain.StrVal, Is.EqualTo("test"));
+                Assert.That(plain.ArrVal, Is.Not.Null);
+                Assert.That(plain.ArrVal, Has.Length.EqualTo(2));
+                Assert.That(plain.ArrVal[0], Is.EqualTo(12.34f).Within(1e-4));
+                Assert.That(plain.ArrVal[1], Is.EqualTo(56.789f).Within(1e-4));
+            });
+        }
+
+        private static void SetupStructTable(FireboltConnection conn)
+        {
+            foreach (var sql in SetupSql)
+            {
+                CreateCommand(conn, sql).ExecuteNonQuery();
+            }
+
+            // Insert a struct row
+            const string insert = $"INSERT INTO {TableName} (id, plain) VALUES (1, struct(1, 'test', [12.34, 56.789]))";
+            CreateCommand(conn, insert).ExecuteNonQuery();
+        }
+
+        private class PlainStructWithAttributes
+        {
+
+            [FireboltStructName("int_val")]
+            public int IntVal { get; init; }
+
+            [FireboltStructName("str_val")]
+            public string StrVal { get; init; } = null!;
+
+            [FireboltStructName("arr_val")]
+            public float[] ArrVal { get; init; } = null!;
+        }
+
+        private class PlainStructWithoutAttributes
+        {
+
+            public int IntVal { get; init; }
+
+            public string StrVal { get; init; } = null!;
+
+            public float[] ArrVal { get; init; } = null!;
+        }
+
+        private static DbCommand CreateCommand(DbConnection conn, string query)
+        {
+            var command = conn.CreateCommand();
+            command.CommandText = query;
+            return command;
+        }
+    }
+}
+
+

--- a/FireboltDotNetSdk.Tests/Unit/FireboltStructNameContractResolverTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltStructNameContractResolverTest.cs
@@ -1,0 +1,98 @@
+using FireboltDotNetSdk.Utils;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace FireboltDotNetSdk.Tests
+{
+    [TestFixture]
+    internal class FireboltStructNameContractResolverTest
+    {
+        private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        {
+            ContractResolver = new FireboltStructNameContractResolver()
+        };
+
+        [Test]
+        public void Serialize_And_Deserialize_With_Property_Attributes()
+        {
+            var obj = new PocoWithAttributes
+            {
+                IntVal = 42,
+                StrVal = "hello",
+                NoAttrProp = "should_be_snake_case"
+            };
+
+            var json = JsonConvert.SerializeObject(obj, Settings);
+            var jo = JObject.Parse(json);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(jo["int_val"]!.Value<int>(), Is.EqualTo(42));
+                Assert.That(jo["str_val"]!.Value<string>(), Is.EqualTo("hello"));
+                Assert.That(jo["no_attr_prop"]!.Value<string>(), Is.EqualTo("should_be_snake_case"));
+            });
+
+            var roundTrip = JsonConvert.DeserializeObject<PocoWithAttributes>(json, Settings)!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(roundTrip.IntVal, Is.EqualTo(42));
+                Assert.That(roundTrip.StrVal, Is.EqualTo("hello"));
+                Assert.That(roundTrip.NoAttrProp, Is.EqualTo("should_be_snake_case"));
+            });
+        }
+
+        [Test]
+        public void Deserialize_With_Ctor_Parameter_Attributes()
+        {
+            var json = "{\"int_val\":7,\"str_val\":\"abc\"}";
+            var obj = JsonConvert.DeserializeObject<CtorMapped>(json, Settings)!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(obj.A, Is.EqualTo(7));
+                Assert.That(obj.B, Is.EqualTo("abc"));
+            });
+        }
+
+        [Test]
+        public void Serialize_With_Getter_Accessor_Attribute()
+        {
+            var obj = new AccessorMapped("ok");
+            var json = JsonConvert.SerializeObject(obj, Settings);
+            var jo = JObject.Parse(json);
+            Assert.That(jo["value"]!.Value<string>(), Is.EqualTo("ok"));
+        }
+
+        private class PocoWithAttributes
+        {
+            [FireboltStructName("int_val")] public int IntVal { get; set; }
+            [FireboltStructName("str_val")] public string StrVal { get; set; } = string.Empty;
+            public string NoAttrProp { get; set; } = string.Empty;
+        }
+
+        private class CtorMapped
+        {
+            public int A { get; }
+            public string B { get; }
+
+            public CtorMapped([FireboltStructName("int_val")] int a,
+                              [FireboltStructName("str_val")] string b)
+            {
+                A = a;
+                B = b;
+            }
+        }
+
+        private class AccessorMapped
+        {
+            public AccessorMapped(string v)
+            {
+                Value = v;
+            }
+
+            [FireboltStructName("value")]
+            public string Value { get; }
+        }
+    }
+}
+
+

--- a/FireboltDotNetSdk.Tests/Unit/FireboltStructNameContractResolverTest.cs
+++ b/FireboltDotNetSdk.Tests/Unit/FireboltStructNameContractResolverTest.cs
@@ -94,5 +94,3 @@ namespace FireboltDotNetSdk.Tests
         }
     }
 }
-
-

--- a/FireboltNETSDK/Client/FireboltDataReader.cs
+++ b/FireboltNETSDK/Client/FireboltDataReader.cs
@@ -23,6 +23,8 @@ using System.Text.RegularExpressions;
 using FireboltDoNetSdk.Utils;
 using FireboltDotNetSdk.Exception;
 using FireboltDotNetSdk.Utils;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace FireboltDotNetSdk.Client
 {
@@ -547,6 +549,44 @@ namespace FireboltDotNetSdk.Client
                 Data = _queryResult.Data.Select(HasRows => new List<object?>() { HasRows[ordinal] }).ToList()
             };
             return new FireboltDataReader(_fullTableName, queryResult, _depth + 1);
+        }
+
+        /// <inheritdoc/>
+        public override T GetFieldValue<T>(int ordinal)
+        {
+            if (IsDBNull(ordinal))
+            {
+                throw new InvalidCastException($"Column #{ordinal} is null (DBNull) and cannot be cast to {typeof(T).Name}");
+            }
+            var value = GetValue(ordinal);
+            switch (value)
+            {
+                case T direct:
+                    return direct;
+
+                case Dictionary<string, object?> dict when typeof(T).IsAssignableFrom(typeof(Dictionary<string, object>)) ||
+                                                           typeof(IDictionary<string, object>).IsAssignableFrom(typeof(T)):
+                    return (T)(object)dict;
+
+                case Dictionary<string, object?> dict:
+                    {
+                        var serializer = new JsonSerializer
+                        {
+                            ContractResolver = new FireboltStructNameContractResolver()
+                        };
+                        var token = JToken.FromObject(dict);
+                        return token.ToObject<T>(serializer)!;
+                    }
+                default:
+                    // Fallback conversion attempt for compatible primitives
+                    return (T)Convert.ChangeType(value, typeof(T));
+            }
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(GetFieldValue<T>(ordinal));
         }
     }
 }

--- a/FireboltNETSDK/Client/FireboltDataReader.cs
+++ b/FireboltNETSDK/Client/FireboltDataReader.cs
@@ -564,8 +564,7 @@ namespace FireboltDotNetSdk.Client
                 case T direct:
                     return direct;
 
-                case Dictionary<string, object?> dict when typeof(T).IsAssignableFrom(typeof(Dictionary<string, object>)) ||
-                                                           typeof(IDictionary<string, object>).IsAssignableFrom(typeof(T)):
+                case Dictionary<string, object?> dict when typeof(T).IsAssignableFrom(typeof(Dictionary<string, object>)):
                     return (T)(object)dict;
 
                 case Dictionary<string, object?> dict:
@@ -575,7 +574,14 @@ namespace FireboltDotNetSdk.Client
                             ContractResolver = new FireboltStructNameContractResolver()
                         };
                         var token = JToken.FromObject(dict);
-                        return token.ToObject<T>(serializer)!;
+                        try
+                        {
+                            return token.ToObject<T>(serializer)!;
+                        }
+                        catch (JsonReaderException ex)
+                        {
+                            throw new InvalidCastException("Cannot convert struct to the specified type", ex);
+                        }
                     }
                 default:
                     // Fallback conversion attempt for compatible primitives

--- a/FireboltNETSDK/Utils/FireboltStructNameAttribute.cs
+++ b/FireboltNETSDK/Utils/FireboltStructNameAttribute.cs
@@ -1,6 +1,6 @@
 namespace FireboltDotNetSdk.Utils
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.Method)]
     public sealed class FireboltStructNameAttribute : Attribute
     {
         public string Name { get; }

--- a/FireboltNETSDK/Utils/FireboltStructNameAttribute.cs
+++ b/FireboltNETSDK/Utils/FireboltStructNameAttribute.cs
@@ -1,0 +1,12 @@
+namespace FireboltDotNetSdk.Utils
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+    public sealed class FireboltStructNameAttribute : Attribute
+    {
+        public string Name { get; }
+        public FireboltStructNameAttribute(string name) => Name = name;
+    }
+
+}
+
+

--- a/FireboltNETSDK/Utils/FireboltStructNameContractResolver.cs
+++ b/FireboltNETSDK/Utils/FireboltStructNameContractResolver.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace FireboltDotNetSdk.Utils
+{
+    public sealed class FireboltStructNameContractResolver : DefaultContractResolver
+    {
+        public FireboltStructNameContractResolver()
+        {
+            // Optional: fallback for props *without* [FromName]
+            NamingStrategy = new SnakeCaseNamingStrategy();
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            // If an explicit JsonProperty is present, let it win
+            if (member.GetCustomAttribute<JsonPropertyAttribute>(true) is not null) return prop;
+            var map = GetFromName(member);
+            if (map is { Name: { Length: > 0 } name })
+                prop.PropertyName = name;
+
+            return prop;
+        }
+
+        protected override IList<JsonProperty> CreateConstructorParameters(
+            ConstructorInfo constructor, JsonPropertyCollection memberProperties)
+        {
+            var parameters = base.CreateConstructorParameters(constructor, memberProperties);
+
+            foreach (var pinfo in constructor.GetParameters())
+            {
+                var map = pinfo.GetCustomAttribute<FireboltStructNameAttribute>(true);
+                if (map is { Name: { Length: > 0 } name })
+                {
+                    var jp = parameters.FirstOrDefault(p => p.PropertyName == pinfo.Name);
+                    if (jp != null) jp.PropertyName = name;
+                }
+            }
+
+            return parameters;
+        }
+
+        private static FireboltStructNameAttribute? GetFromName(MemberInfo member)
+        {
+            // Attribute on property/field
+            if (member.GetCustomAttribute<FireboltStructNameAttribute>(true) is { } a) return a;
+
+            // …or on accessors
+            if (member is PropertyInfo pi)
+            {
+                return pi.GetGetMethod(true)?.GetCustomAttribute<FireboltStructNameAttribute>(true)
+                       ?? pi.GetSetMethod(true)?.GetCustomAttribute<FireboltStructNameAttribute>(true);
+            }
+            return null;
+        }
+    }
+}
+
+

--- a/FireboltNETSDK/Utils/FireboltStructNameContractResolver.cs
+++ b/FireboltNETSDK/Utils/FireboltStructNameContractResolver.cs
@@ -12,12 +12,14 @@ namespace FireboltDotNetSdk.Utils
             NamingStrategy = new SnakeCaseNamingStrategy();
         }
 
+        /// <summary>
+        /// Override JSON.NET's property creation.
+        /// If a member has a [FireboltStructName("...")] mapping, use that name as the JSON property name instead of the default.
+        /// </summary>
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var prop = base.CreateProperty(member, memberSerialization);
 
-            // If an explicit JsonProperty is present, let it win
-            if (member.GetCustomAttribute<JsonPropertyAttribute>(true) is not null) return prop;
             var map = GetFromName(member);
             if (map is { Name: { Length: > 0 } name })
                 prop.PropertyName = name;
@@ -25,6 +27,10 @@ namespace FireboltDotNetSdk.Utils
             return prop;
         }
 
+        /// <summary>
+        /// Override JSON.NET's default constructor parameter mapping.
+        /// If a parameter has [FireboltStructName("...")], use that value as the JSON property name instead of the parameter's name.
+        /// </summary>
         protected override IList<JsonProperty> CreateConstructorParameters(
             ConstructorInfo constructor, JsonPropertyCollection memberProperties)
         {


### PR DESCRIPTION
This PR adds support for deserializing struct directly into .NET classes, using the default snake case convention based on property names, or by using the new FireboltStructNameAttribute to map properties with a different name than the one from the result.